### PR TITLE
Adding auctions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/ds-test"]
 	path = lib/ds-test
 	url = https://github.com/dapphub/ds-test
+[submodule "lib/ds-value"]
+	path = lib/ds-value
+	url = https://github.com/dapphub/ds-value

--- a/src/Abaci.sol
+++ b/src/Abaci.sol
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/// Abaci.sol -- price decrease functions for auctions
+
+// Copyright (C) 2020-2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.13;
+
+interface Abacus {
+    // 1st arg: initial price               [ray]
+    // 2nd arg: seconds since auction start [seconds]
+    // returns: current auction price       [ray]
+    function price(uint256, uint256) external view returns (uint256);
+}
+
+contract LinearDecrease is Abacus {
+
+    // --- Data ---
+    mapping (address => uint256) public wards;
+
+    uint256 public tau;  // Seconds after auction start when the price reaches zero [seconds]
+
+    // --- Events ---
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
+
+    event File(bytes32 indexed what, uint256 data);
+
+    modifier auth {
+        require(wards[msg.sender] == 1, "LinearDecrease/not-authorized");
+        _;
+    }
+
+    // --- Init ---
+    constructor() {
+        wards[msg.sender] = 1;
+        emit Rely(msg.sender);
+    }
+
+    // --- Administration ---
+    function rely(address usr) external auth {
+        wards[usr] = 1;
+        emit Rely(usr);
+    }
+
+    function deny(address usr) external auth {
+        wards[usr] = 0;
+        emit Deny(usr);
+    }
+
+    function file(bytes32 what, uint256 data) external auth {
+        if (what ==  "tau") tau = data;
+        else revert("LinearDecrease/file-unrecognized-param");
+        emit File(what, data);
+    }
+
+    // --- Math ---
+    uint256 constant RAY = 10 ** 27;
+
+    // Price calculation when price is decreased linearly in proportion to time:
+    // tau: The number of seconds after the start of the auction where the price will hit 0
+    // top: Initial price
+    // dur: current seconds since the start of the auction
+    //
+    // Returns y = top * ((tau - dur) / tau)
+    //
+    // Note the internal call to mul multiples by RAY, thereby ensuring that the rmul calculation
+    // which utilizes top and tau (RAY values) is also a RAY value.
+    function price(uint256 top, uint256 dur) override external view returns (uint256) {
+        if (dur >= tau) return 0;
+        uint256 t;
+        unchecked {
+            t = tau - dur;
+        }
+        return top * t / tau;
+    }
+}
+
+contract StairstepExponentialDecrease is Abacus {
+
+    // --- Data ---
+    mapping (address => uint256) public wards;
+
+    uint256 public step; // Length of time between price drops [seconds]
+    uint256 public cut;  // Per-step multiplicative factor     [ray]
+
+    // --- Events ---
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
+
+    event File(bytes32 indexed what, uint256 data);
+
+    modifier auth {
+        require(wards[msg.sender] == 1, "StairstepExponentialDecrease/not-authorized");
+        _;
+    }
+
+    // --- Init ---
+    // @notice: `cut` and `step` values must be correctly set for
+    //     this contract to return a valid price
+    constructor() {
+        wards[msg.sender] = 1;
+        emit Rely(msg.sender);
+    }
+
+    // --- Administration ---
+    function rely(address usr) external auth {
+        wards[usr] = 1;
+        emit Rely(usr);
+    }
+
+    function deny(address usr) external auth {
+        wards[usr] = 0;
+        emit Deny(usr);
+    }
+
+    function file(bytes32 what, uint256 data) external auth {
+        if      (what ==  "cut") require((cut = data) <= RAY, "StairstepExponentialDecrease/cut-gt-RAY");
+        else if (what == "step") step = data;
+        else revert("StairstepExponentialDecrease/file-unrecognized-param");
+        emit File(what, data);
+    }
+
+    // --- Math ---
+    uint256 constant RAY = 10 ** 27;
+    // optimized version from dss PR #78
+    function rpow(uint256 x, uint256 n, uint256 b) internal pure returns (uint256 z) {
+        assembly {
+            switch n case 0 { z := b }
+            default {
+                switch x case 0 { z := 0 }
+                default {
+                    switch mod(n, 2) case 0 { z := b } default { z := x }
+                    let half := div(b, 2)  // for rounding.
+                    for { n := div(n, 2) } n { n := div(n,2) } {
+                        let xx := mul(x, x)
+                        if shr(128, x) { revert(0,0) }
+                        let xxRound := add(xx, half)
+                        if lt(xxRound, xx) { revert(0,0) }
+                        x := div(xxRound, b)
+                        if mod(n,2) {
+                            let zx := mul(z, x)
+                            if and(iszero(iszero(x)), iszero(eq(div(zx, x), z))) { revert(0,0) }
+                            let zxRound := add(zx, half)
+                            if lt(zxRound, zx) { revert(0,0) }
+                            z := div(zxRound, b)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // top: initial price
+    // dur: seconds since the auction has started
+    // step: seconds between a price drop
+    // cut: cut encodes the percentage to decrease per step.
+    //   For efficiency, the values is set as (1 - (% value / 100)) * RAY
+    //   So, for a 1% decrease per step, cut would be (1 - 0.01) * RAY
+    //
+    // returns: top * (cut ^ dur)
+    //
+    //
+    function price(uint256 top, uint256 dur) override external view returns (uint256) {
+        return top * rpow(cut, dur / step, RAY) / RAY;
+    }
+}
+
+// While an equivalent function can be obtained by setting step = 1 in StairstepExponentialDecrease,
+// this continous (i.e. per-second) exponential decrease has be implemented as it is more gas-efficient
+// than using the stairstep version with step = 1 (primarily due to 1 fewer SLOAD per price calculation).
+contract ExponentialDecrease is Abacus {
+
+    // --- Data ---
+    mapping (address => uint256) public wards;
+
+    uint256 public cut;  // Per-second multiplicative factor [ray]
+
+    // --- Events ---
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
+
+    event File(bytes32 indexed what, uint256 data);
+
+    modifier auth {
+        require(wards[msg.sender] == 1, "ExponentialDecrease/not-authorized");
+        _;
+    }
+
+    // --- Init ---
+    // @notice: `cut` value must be correctly set for
+    //     this contract to return a valid price
+    constructor() {
+        wards[msg.sender] = 1;
+        emit Rely(msg.sender);
+    }
+
+    // --- Administration ---
+    function rely(address usr) external auth {
+        wards[usr] = 1;
+        emit Rely(usr);
+    }
+
+    function deny(address usr) external auth {
+        wards[usr] = 0;
+        emit Deny(usr);
+    }
+
+    function file(bytes32 what, uint256 data) external auth {
+        if      (what ==  "cut") require((cut = data) <= RAY, "ExponentialDecrease/cut-gt-RAY");
+        else revert("ExponentialDecrease/file-unrecognized-param");
+        emit File(what, data);
+    }
+
+    // --- Math ---
+    uint256 constant RAY = 10 ** 27;
+    // optimized version from dss PR #78
+    function rpow(uint256 x, uint256 n, uint256 b) internal pure returns (uint256 z) {
+        assembly {
+            switch n case 0 { z := b }
+            default {
+                switch x case 0 { z := 0 }
+                default {
+                    switch mod(n, 2) case 0 { z := b } default { z := x }
+                    let half := div(b, 2)  // for rounding.
+                    for { n := div(n, 2) } n { n := div(n,2) } {
+                        let xx := mul(x, x)
+                        if shr(128, x) { revert(0,0) }
+                        let xxRound := add(xx, half)
+                        if lt(xxRound, xx) { revert(0,0) }
+                        x := div(xxRound, b)
+                        if mod(n,2) {
+                            let zx := mul(z, x)
+                            if and(iszero(iszero(x)), iszero(eq(div(zx, x), z))) { revert(0,0) }
+                            let zxRound := add(zx, half)
+                            if lt(zxRound, zx) { revert(0,0) }
+                            z := div(zxRound, b)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // top: initial price
+    // dur: seconds since the auction has started
+    // cut: cut encodes the percentage to decrease per second.
+    //   For efficiency, the values is set as (1 - (% value / 100)) * RAY
+    //   So, for a 1% decrease per second, cut would be (1 - 0.01) * RAY
+    //
+    // returns: top * (cut ^ dur)
+    //
+    function price(uint256 top, uint256 dur) override external view returns (uint256) {
+        return top * rpow(cut, dur, RAY) / RAY;
+    }
+}

--- a/src/Clipper.sol
+++ b/src/Clipper.sol
@@ -1,0 +1,475 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/// Clipper.sol -- Dai auction module 2.0
+
+// Copyright (C) 2020-2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.13;
+
+interface VatLike {
+    function move(address,address,uint256) external;
+    function flux(bytes32,address,address,uint256) external;
+    function ilks(bytes32) external returns (uint256, uint256, uint256, uint256, uint256);
+    function suck(address,address,uint256) external;
+    function dust(bytes32) external view returns (uint256);
+}
+
+interface PipLike {
+    function peek() external returns (bytes32, bool);
+}
+
+interface SpotterLike {
+    function par() external returns (uint256);
+    function ilks(bytes32) external returns (PipLike, uint256);
+}
+
+interface DogLike {
+    function chop(bytes32) external returns (uint256);
+    function digs(bytes32, uint256) external;
+}
+
+interface ClipperCallee {
+    function clipperCall(address, uint256, uint256, bytes calldata) external;
+}
+
+interface AbacusLike {
+    function price(uint256, uint256) external view returns (uint256);
+}
+
+contract Clipper {
+    // --- Data ---
+    mapping (address => uint256) public wards;
+
+    bytes32  immutable public ilk;   // Collateral type of this Clipper
+    VatLike  immutable public vat;   // Core CDP Engine
+
+    DogLike     public dog;      // Liquidation module
+    address     public vow;      // Recipient of dai raised in auctions
+    SpotterLike public spotter;  // Collateral price module
+    AbacusLike  public calc;     // Current price calculator
+
+    uint256 public buf;    // Multiplicative factor to increase starting price                  [ray]
+    uint256 public tail;   // Time elapsed before auction reset                                 [seconds]
+    uint256 public cusp;   // Percentage drop before auction reset                              [ray]
+    uint64  public chip;   // Percentage of tab to suck from vow to incentivize keepers         [wad]
+    uint192 public tip;    // Flat fee to suck from vow to incentivize keepers                  [rad]
+    uint256 public chost;  // Cache the ilk dust times the ilk chop to prevent excessive SLOADs [rad]
+
+    uint256   public kicks;   // Total auctions
+    uint256[] public active;  // Array of active auction ids
+
+    struct Sale {
+        uint256 pos;  // Index in active array
+        uint256 tab;  // Dai to raise       [rad]
+        uint256 lot;  // collateral to sell [wad]
+        address usr;  // Liquidated CDP
+        uint96  tic;  // Auction start time
+        uint256 top;  // Starting price     [ray]
+    }
+    mapping(uint256 => Sale) public sales;
+
+    uint256 internal locked;
+
+    // Levels for circuit breaker
+    // 0: no breaker
+    // 1: no new kick()
+    // 2: no new kick() or redo()
+    // 3: no new kick(), redo(), or take()
+    uint256 public stopped = 0;
+
+    // --- Events ---
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
+
+    event File(bytes32 indexed what, uint256 data);
+    event File(bytes32 indexed what, address data);
+
+    event Kick(
+        uint256 indexed id,
+        uint256 top,
+        uint256 tab,
+        uint256 lot,
+        address indexed usr,
+        address indexed kpr,
+        uint256 coin
+    );
+    event Take(
+        uint256 indexed id,
+        uint256 max,
+        uint256 price,
+        uint256 owe,
+        uint256 tab,
+        uint256 lot,
+        address indexed usr
+    );
+    event Redo(
+        uint256 indexed id,
+        uint256 top,
+        uint256 tab,
+        uint256 lot,
+        address indexed usr,
+        address indexed kpr,
+        uint256 coin
+    );
+
+    event Yank(uint256 id);
+
+    modifier auth {
+        require(wards[msg.sender] == 1, "Clipper/not-authorized");
+        _;
+    }
+
+    modifier lock {
+        require(locked == 0, "Clipper/system-locked");
+        locked = 1;
+        _;
+        locked = 0;
+    }
+
+    modifier isStopped(uint256 level) {
+        require(stopped < level, "Clipper/stopped-incorrect");
+        _;
+    }
+
+    // --- Init ---
+    constructor(address vat_, address spotter_, address dog_, bytes32 ilk_) {
+        vat     = VatLike(vat_);
+        spotter = SpotterLike(spotter_);
+        dog     = DogLike(dog_);
+        ilk     = ilk_;
+        buf     = RAY;
+        wards[msg.sender] = 1;
+        emit Rely(msg.sender);
+    }
+
+    // --- Administration ---
+    function file(bytes32 what, uint256 data) external auth lock {
+        if      (what == "buf")         buf = data;
+        else if (what == "tail")       tail = data;           // Time elapsed before auction reset
+        else if (what == "cusp")       cusp = data;           // Percentage drop before auction reset
+        else if (what == "chip")       chip = uint64(data);   // Percentage of tab to incentivize (max: 2^64 - 1 => 18.xxx WAD = 18xx%)
+        else if (what == "tip")         tip = uint192(data);  // Flat fee to incentivize keepers (max: 2^192 - 1 => 6.277T RAD)
+        else if (what == "stopped") stopped = data;           // Set breaker (0, 1, 2, or 3)
+        else revert("Clipper/file-unrecognized-param");
+        emit File(what, data);
+    }
+
+    function file(bytes32 what, address data) external auth lock {
+        if (what == "spotter") spotter = SpotterLike(data);
+        else if (what == "dog")    dog = DogLike(data);
+        else if (what == "vow")    vow = data;
+        else if (what == "calc")  calc = AbacusLike(data);
+        else revert("Clipper/file-unrecognized-param");
+        emit File(what, data);
+    }
+
+    // --- Math ---
+    uint256 constant BLN = 10 **  9;
+    uint256 constant WAD = 10 ** 18;
+    uint256 constant RAY = 10 ** 27;
+
+    function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        z = x <= y ? x : y;
+    }
+    function wmul(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        z = x * y / WAD;
+    }
+    function rmul(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        z = x * y / RAY;
+    }
+    function rdiv(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        z = x * RAY / y;
+    }
+
+    // --- Auction ---
+
+    // get the price directly from the OSM
+    // Could get this from rmul(Vat.ilks(ilk).spot, Spotter.mat()) instead, but
+    // if mat has changed since the last poke, the resulting value will be
+    // incorrect.
+    function getFeedPrice() internal returns (uint256 feedPrice) {
+        (PipLike pip, ) = spotter.ilks(ilk);
+        (bytes32 val, bool has) = pip.peek();
+        require(has, "Clipper/invalid-price");
+        feedPrice = rdiv(uint256(val) * BLN, spotter.par());
+    }
+
+    // start an auction
+    // note: trusts the caller to transfer collateral to the contract
+    // The starting price `top` is obtained as follows:
+    //
+    //     top = val * buf / par
+    //
+    // Where `val` is the collateral's unitary value in USD, `buf` is a
+    // multiplicative factor to increase the starting price, and `par` is a
+    // reference per DAI.
+    function kick(
+        uint256 tab,  // Debt                   [rad]
+        uint256 lot,  // Collateral             [wad]
+        address usr,  // Address that will receive any leftover collateral
+        address kpr   // Address that will receive incentives
+    ) external auth lock isStopped(1) returns (uint256 id) {
+        // Input validation
+        require(tab  >          0, "Clipper/zero-tab");
+        require(lot  >          0, "Clipper/zero-lot");
+        require(usr != address(0), "Clipper/zero-usr");
+        unchecked {
+            id = ++kicks;
+        }
+        require(id   >          0, "Clipper/overflow");
+
+        active.push(id);
+
+        unchecked {
+            sales[id].pos = active.length - 1;
+        }
+
+        sales[id].tab = tab;
+        sales[id].lot = lot;
+        sales[id].usr = usr;
+        sales[id].tic = uint96(block.timestamp);
+
+        uint256 top;
+        top = rmul(getFeedPrice(), buf);
+        require(top > 0, "Clipper/zero-top-price");
+        sales[id].top = top;
+
+        // incentive to kick auction
+        uint256 _tip  = tip;
+        uint256 _chip = chip;
+        uint256 coin;
+        if (_tip > 0 || _chip > 0) {
+            coin = _tip + wmul(tab, _chip);
+            vat.suck(vow, kpr, coin);
+        }
+
+        emit Kick(id, top, tab, lot, usr, kpr, coin);
+    }
+
+    // Reset an auction
+    // See `kick` above for an explanation of the computation of `top`.
+    function redo(
+        uint256 id,  // id of the auction to reset
+        address kpr  // Address that will receive incentives
+    ) external lock isStopped(2) {
+        // Read auction data
+        address usr = sales[id].usr;
+        uint96  tic = sales[id].tic;
+        uint256 top = sales[id].top;
+
+        require(usr != address(0), "Clipper/not-running-auction");
+
+        // Check that auction needs reset
+        // and compute current price [ray]
+        (bool done,) = status(tic, top);
+        require(done, "Clipper/cannot-reset");
+
+        uint256 tab   = sales[id].tab;
+        uint256 lot   = sales[id].lot;
+        sales[id].tic = uint96(block.timestamp);
+
+        uint256 feedPrice = getFeedPrice();
+        top = rmul(feedPrice, buf);
+        require(top > 0, "Clipper/zero-top-price");
+        sales[id].top = top;
+
+        // incentive to redo auction
+        uint256 _tip  = tip;
+        uint256 _chip = chip;
+        uint256 coin;
+        if (_tip > 0 || _chip > 0) {
+            uint256 _chost = chost;
+            if (tab >= _chost && lot * feedPrice >= _chost) {
+                coin = _tip + wmul(tab, _chip);
+                vat.suck(vow, kpr, coin);
+            }
+        }
+
+        emit Redo(id, top, tab, lot, usr, kpr, coin);
+    }
+
+    // Buy up to `amt` of collateral from the auction indexed by `id`.
+    // 
+    // Auctions will not collect more DAI than their assigned DAI target,`tab`;
+    // thus, if `amt` would cost more DAI than `tab` at the current price, the
+    // amount of collateral purchased will instead be just enough to collect `tab` DAI.
+    //
+    // To avoid partial purchases resulting in very small leftover auctions that will
+    // never be cleared, any partial purchase must leave at least `Clipper.chost`
+    // remaining DAI target. `chost` is an asynchronously updated value equal to
+    // (Vat.dust * Dog.chop(ilk) / WAD) where the values are understood to be determined
+    // by whatever they were when Clipper.upchost() was last called. Purchase amounts
+    // will be minimally decreased when necessary to respect this limit; i.e., if the
+    // specified `amt` would leave `tab < chost` but `tab > 0`, the amount actually
+    // purchased will be such that `tab == chost`.
+    //
+    // If `tab <= chost`, partial purchases are no longer possible; that is, the remaining
+    // collateral can only be purchased entirely, or not at all.
+    function take(
+        uint256 id,           // Auction id
+        uint256 amt,          // Upper limit on amount of collateral to buy  [wad]
+        uint256 max,          // Maximum acceptable price (DAI / collateral) [ray]
+        address who,          // Receiver of collateral and external call address
+        bytes calldata data   // Data to pass in external call; if length 0, no call is done
+    ) external lock isStopped(3) {
+
+        address usr = sales[id].usr;
+        uint96  tic = sales[id].tic;
+
+        require(usr != address(0), "Clipper/not-running-auction");
+
+        uint256 price;
+        {
+            bool done;
+            (done, price) = status(tic, sales[id].top);
+
+            // Check that auction doesn't need reset
+            require(!done, "Clipper/needs-reset");
+        }
+
+        // Ensure price is acceptable to buyer
+        require(max >= price, "Clipper/too-expensive");
+
+        uint256 lot = sales[id].lot;
+        uint256 tab = sales[id].tab;
+        uint256 owe;
+
+        {
+            // Purchase as much as possible, up to amt
+            uint256 slice = min(lot, amt);  // slice <= lot
+
+            // DAI needed to buy a slice of this sale
+            owe = slice * price;
+
+            // Don't collect more than tab of DAI
+            if (owe > tab) {
+                // Total debt will be paid
+                owe = tab;                  // owe' <= owe
+                // Adjust slice
+                slice = owe / price;        // slice' = owe' / price <= owe / price == slice <= lot
+            } else if (owe < tab && slice < lot) {
+                // If slice == lot => auction completed => dust doesn't matter
+                uint256 _chost = chost;
+                unchecked {
+                    if (tab - owe < _chost) {    // safe as owe < tab
+                        // If tab <= chost, buyers have to take the entire lot.
+                        require(tab > _chost, "Clipper/no-partial-purchase");
+                        // Adjust amount to pay
+                        owe = tab - _chost;      // owe' <= owe
+                        // Adjust slice
+                        slice = owe / price;     // slice' = owe' / price < owe / price == slice < lot
+                    }
+                }
+            }
+
+            unchecked {
+                // Calculate remaining tab after operation
+                tab = tab - owe;  // safe since owe <= tab
+                // Calculate remaining lot after operation
+                lot = lot - slice;
+            }
+
+            // Send collateral to who
+            vat.flux(ilk, address(this), who, slice);
+
+            // Do external call (if data is defined) but to be
+            // extremely careful we don't allow to do it to the two
+            // contracts which the Clipper needs to be authorized
+            DogLike dog_ = dog;
+            if (data.length > 0 && who != address(vat) && who != address(dog_)) {
+                ClipperCallee(who).clipperCall(msg.sender, owe, slice, data);
+            }
+
+            // Get DAI from caller
+            vat.move(msg.sender, vow, owe);
+
+            // Removes Dai out for liquidation from accumulator
+            unchecked {
+                dog_.digs(ilk, lot == 0 ? tab + owe : owe);
+            }
+        }
+
+        if (lot == 0) {
+            _remove(id);
+        } else if (tab == 0) {
+            vat.flux(ilk, address(this), usr, lot);
+            _remove(id);
+        } else {
+            sales[id].tab = tab;
+            sales[id].lot = lot;
+        }
+
+        emit Take(id, max, price, owe, tab, lot, usr);
+    }
+
+    function _remove(uint256 id) internal {
+        uint256 _move;
+        unchecked {
+            _move = active[active.length - 1];
+        }
+        if (id != _move) {
+            uint256 _index   = sales[id].pos;
+            active[_index]   = _move;
+            sales[_move].pos = _index;
+        }
+        active.pop();
+        delete sales[id];
+    }
+
+    // The number of active auctions
+    function count() external view returns (uint256) {
+        return active.length;
+    }
+
+    // Return the entire array of active auctions
+    function list() external view returns (uint256[] memory) {
+        return active;
+    }
+
+    // Externally returns boolean for if an auction needs a redo and also the current price
+    function getStatus(uint256 id) external view returns (bool needsRedo, uint256 price, uint256 lot, uint256 tab) {
+        // Read auction data
+        address usr = sales[id].usr;
+        uint96  tic = sales[id].tic;
+
+        bool done;
+        (done, price) = status(tic, sales[id].top);
+
+        needsRedo = usr != address(0) && done;
+        lot = sales[id].lot;
+        tab = sales[id].tab;
+    }
+
+    // Internally returns boolean for if an auction needs a redo
+    function status(uint96 tic, uint256 top) internal view returns (bool done, uint256 price) {
+        price = calc.price(top, block.timestamp - tic);
+        done  = (block.timestamp - tic > tail || rdiv(price, top) < cusp);
+    }
+
+    // Public function to update the cached dust*chop value.
+    function upchost() external {
+        chost = wmul(VatLike(vat).dust(ilk), dog.chop(ilk));
+    }
+
+    // Cancel an auction during ES or via governance action.
+    function yank(uint256 id) external auth lock {
+        require(sales[id].usr != address(0), "Clipper/not-running-auction");
+        dog.digs(ilk, sales[id].tab);
+        vat.flux(ilk, address(this), msg.sender, sales[id].lot);
+        _remove(id);
+        emit Yank(id);
+    }
+}

--- a/src/Clipper.sol
+++ b/src/Clipper.sol
@@ -156,6 +156,16 @@ contract Clipper {
     }
 
     // --- Administration ---
+    function rely(address usr) external auth {
+        wards[usr] = 1;
+        emit Rely(usr);
+    }
+
+    function deny(address usr) external auth {
+        wards[usr] = 0;
+        emit Deny(usr);
+    }
+    
     function file(bytes32 what, uint256 data) external auth lock {
         if      (what == "buf")         buf = data;
         else if (what == "tail")       tail = data;           // Time elapsed before auction reset

--- a/src/Dog.sol
+++ b/src/Dog.sol
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/// Dog.sol -- Dai liquidation module 2.0
+
+// Copyright (C) 2020-2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.13;
+
+interface ClipperLike {
+    function ilk() external view returns (bytes32);
+    function kick(
+        uint256 tab,
+        uint256 lot,
+        address usr,
+        address kpr
+    ) external returns (uint256);
+}
+
+interface VatLike {
+    function ilks(bytes32) external view returns (
+        uint256 Art,  // [wad]
+        uint256 rate, // [ray]
+        uint256 spot, // [ray]
+        uint256 line, // [rad]
+        uint256 dust  // [rad]
+    );
+    function urns(bytes32,address) external view returns (
+        uint256 ink,  // [wad]
+        uint256 art   // [wad]
+    );
+    function grab(bytes32,address,address,address,int256,int256) external;
+    function hope(address) external;
+    function nope(address) external;
+}
+
+interface VowLike {
+    function fess(uint256) external;
+}
+
+contract Dog {
+    // --- Data ---
+    mapping (address => uint256) public wards;
+
+    struct Ilk {
+        address clip;  // Liquidator
+        uint256 chop;  // Liquidation Penalty                                          [wad]
+        uint256 hole;  // Max DAI needed to cover debt+fees of active auctions per ilk [rad]
+        uint256 dirt;  // Amt DAI needed to cover debt+fees of active auctions per ilk [rad]
+    }
+
+    VatLike immutable public vat;  // CDP Engine
+
+    mapping (bytes32 => Ilk) public ilks;
+
+    VowLike public vow;   // Debt Engine
+    uint256 public live;  // Active Flag
+    uint256 public Hole;  // Max DAI needed to cover debt+fees of active auctions [rad]
+    uint256 public Dirt;  // Amt DAI needed to cover debt+fees of active auctions [rad]
+
+    // --- Events ---
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
+
+    event File(bytes32 indexed what, uint256 data);
+    event File(bytes32 indexed what, address data);
+    event File(bytes32 indexed ilk, bytes32 indexed what, uint256 data);
+    event File(bytes32 indexed ilk, bytes32 indexed what, address clip);
+
+    event Bark(
+      bytes32 indexed ilk,
+      address indexed urn,
+      uint256 ink,
+      uint256 art,
+      uint256 due,
+      address clip,
+      uint256 indexed id
+    );
+    event Digs(bytes32 indexed ilk, uint256 rad);
+    event Cage();
+
+    modifier auth {
+        require(wards[msg.sender] == 1, "Dog/not-authorized");
+        _;
+    }
+
+    // --- Init ---
+    constructor(address vat_) {
+        wards[msg.sender] = 1;
+        vat = VatLike(vat_);
+        live = 1;
+        emit Rely(msg.sender);
+    }
+
+    // --- Math ---
+    uint256 constant WAD = 10 ** 18;
+
+    function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        z = x <= y ? x : y;
+    }
+
+    // --- Administration ---
+    function rely(address usr) external auth {
+        wards[usr] = 1;
+        emit Rely(usr);
+    }
+
+    function deny(address usr) external auth {
+        wards[usr] = 0;
+        emit Deny(usr);
+    }
+
+    function file(bytes32 what, address data) external auth {
+        if (what == "vow") vow = VowLike(data);
+        else revert("Dog/file-unrecognized-param");
+        emit File(what, data);
+    }
+
+    function file(bytes32 what, uint256 data) external auth {
+        if (what == "Hole") Hole = data;
+        else revert("Dog/file-unrecognized-param");
+        emit File(what, data);
+    }
+    
+    function file(bytes32 ilk, bytes32 what, uint256 data) external auth {
+        if (what == "chop") {
+            require(data >= WAD, "Dog/file-chop-lt-WAD");
+            ilks[ilk].chop = data;
+        } else if (what == "hole") ilks[ilk].hole = data;
+        else revert("Dog/file-unrecognized-param");
+        emit File(ilk, what, data);
+    }
+
+    function file(bytes32 ilk, bytes32 what, address clip) external auth {
+        if (what == "clip") {
+            require(ilk == ClipperLike(clip).ilk(), "Dog/file-ilk-neq-clip.ilk");
+            ilks[ilk].clip = clip;
+        } else revert("Dog/file-unrecognized-param");
+        emit File(ilk, what, clip);
+    }
+
+    function chop(bytes32 ilk) external view returns (uint256) {
+        return ilks[ilk].chop;
+    }
+
+    // --- CDP Liquidation: all bark and no bite ---
+    //
+    // Liquidate a Vault and start a Dutch auction to sell its collateral for DAI.
+    //
+    // The third argument is the address that will receive the liquidation reward, if any.
+    //
+    // The entire Vault will be liquidated except when the target amount of DAI to be raised in
+    // the resulting auction (debt of Vault + liquidation penalty) causes either Dirt to exceed
+    // Hole or ilk.dirt to exceed ilk.hole by an economically significant amount. In that
+    // case, a partial liquidation is performed to respect the global and per-ilk limits on
+    // outstanding DAI target. The one exception is if the resulting auction would likely
+    // have too little collateral to be interesting to Keepers (debt taken from Vault < ilk.dust),
+    // in which case the function reverts. Please refer to the code and comments within if
+    // more detail is desired.
+    function bark(bytes32 ilk, address urn, address kpr) external returns (uint256 id) {
+        require(live == 1, "Dog/not-live");
+
+        (uint256 ink, uint256 art) = vat.urns(ilk, urn);
+        Ilk memory milk = ilks[ilk];
+        uint256 dart;
+        uint256 rate;
+        uint256 dust;
+        {
+            uint256 spot;
+            (,rate, spot,, dust) = vat.ilks(ilk);
+            require(spot > 0 && ink * spot < art * rate, "Dog/not-unsafe");
+
+            // Get the minimum value between:
+            // 1) Remaining space in the general Hole
+            // 2) Remaining space in the collateral hole
+            require(Hole > Dirt && milk.hole > milk.dirt, "Dog/liquidation-limit-hit");
+            uint256 room = min(Hole - Dirt, milk.hole - milk.dirt);
+
+            // uint256.max()/(RAD*WAD) = 115,792,089,237,316
+            dart = min(art, room * WAD / rate / milk.chop);
+
+            // Partial liquidation edge case logic
+            if (art > dart) {
+                if ((art - dart) * rate < dust) {
+
+                    // If the leftover Vault would be dusty, just liquidate it entirely.
+                    // This will result in at least one of dirt_i > hole_i or Dirt > Hole becoming true.
+                    // The amount of excess will be bounded above by ceiling(dust_i * chop_i / WAD).
+                    // This deviation is assumed to be small compared to both hole_i and Hole, so that
+                    // the extra amount of target DAI over the limits intended is not of economic concern.
+                    dart = art;
+                } else {
+
+                    // In a partial liquidation, the resulting auction should also be non-dusty.
+                    require(dart * rate >= dust, "Dog/dusty-auction-from-partial-liquidation");
+                }
+            }
+        }
+
+        uint256 dink = ink * dart / art;
+
+        require(dink > 0, "Dog/null-auction");
+        require(dart <= 2**255 && dink <= 2**255, "Dog/overflow");
+
+        vat.grab(
+            ilk, urn, milk.clip, address(vow), -int256(dink), -int256(dart)
+        );
+
+        uint256 due = dart * rate;
+        vow.fess(due);
+
+        {   // Avoid stack too deep
+            // This calcuation will overflow if dart*rate exceeds ~10^14
+            uint256 tab = due * milk.chop / WAD;
+            Dirt = Dirt + tab;
+            ilks[ilk].dirt = milk.dirt + tab;
+
+            id = ClipperLike(milk.clip).kick({
+                tab: tab,
+                lot: dink,
+                usr: urn,
+                kpr: kpr
+            });
+        }
+
+        emit Bark(ilk, urn, dink, dart, due, milk.clip, id);
+    }
+
+    function digs(bytes32 ilk, uint256 rad) external auth {
+        Dirt = Dirt - rad;
+        ilks[ilk].dirt = ilks[ilk].dirt - rad;
+        emit Digs(ilk, rad);
+    }
+
+    function cage() external auth {
+        live = 0;
+        emit Cage();
+    }
+}

--- a/src/Dog.sol
+++ b/src/Dog.sol
@@ -186,14 +186,21 @@ contract Dog {
             // 1) Remaining space in the general Hole
             // 2) Remaining space in the collateral hole
             require(Hole > Dirt && milk.hole > milk.dirt, "Dog/liquidation-limit-hit");
-            uint256 room = min(Hole - Dirt, milk.hole - milk.dirt);
+            uint256 room;
+            unchecked {
+                room = min(Hole - Dirt, milk.hole - milk.dirt);
+            }
 
             // uint256.max()/(RAD*WAD) = 115,792,089,237,316
             dart = min(art, room * WAD / rate / milk.chop);
 
             // Partial liquidation edge case logic
             if (art > dart) {
-                if ((art - dart) * rate < dust) {
+                uint256 delta;
+                unchecked {
+                    delta = art - dart;
+                }
+                if (delta * rate < dust) {
 
                     // If the leftover Vault would be dusty, just liquidate it entirely.
                     // This will result in at least one of dirt_i > hole_i or Dirt > Hole becoming true.

--- a/src/test/Abaci.t.sol
+++ b/src/test/Abaci.t.sol
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// abaci.t.sol -- tests for abaci.sol
+
+// Copyright (C) 2021-2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.13;
+
+import "ds-test/test.sol";
+
+import "../Abaci.sol";
+
+interface Hevm {
+    function warp(uint256) external;
+    function store(address,bytes32,bytes32) external;
+}
+
+contract ClipperTest is DSTest {
+    Hevm hevm;
+
+    uint256 RAY = 10 ** 27;
+
+    // CHEAT_CODE = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D
+    bytes20 constant CHEAT_CODE =
+        bytes20(uint160(uint256(keccak256('hevm cheat code'))));
+
+    uint256 constant startTime = 604411200; // Used to avoid issues with `now`
+
+    function setUp() public {
+        hevm = Hevm(address(CHEAT_CODE));
+        hevm.warp(startTime);
+    }
+
+    function assertEqWithinTolerance(
+        uint256 x,
+        uint256 y,
+        uint256 tolerance) internal {
+            uint256 diff;
+            if (x >= y) {
+                diff = x - y;
+            } else {
+                diff = y - x;
+            }
+            assertTrue(diff <= tolerance);
+    }
+
+    function checkExpDecrease(
+        StairstepExponentialDecrease calc,
+        uint256 cut,
+        uint256 step,
+        uint256 top,
+        uint256 tic,
+        uint256 percentDecrease,
+        uint256 testTime,
+        uint256 tolerance
+    )
+        public
+    {
+        uint256 price;
+        uint256 lastPrice;
+        uint256 testPrice;
+
+        hevm.warp(startTime);
+        calc.file(bytes32("step"), step);
+        calc.file(bytes32("cut"),  cut);
+        price = calc.price(top, block.timestamp - tic);
+        assertEq(price, top);
+
+        for(uint256 i = 1; i < testTime; i += 1) {
+            hevm.warp(startTime + i);
+            lastPrice = price;
+            price = calc.price(top, block.timestamp - tic);
+            // Stairstep calculation
+            if (i % step == 0) { testPrice = lastPrice * percentDecrease / RAY; }
+            else               { testPrice = lastPrice; }
+            assertEqWithinTolerance(testPrice, price, tolerance);
+        }
+    }
+
+    function test_stairstep_exp_decrease() public {
+        StairstepExponentialDecrease calc = new StairstepExponentialDecrease();
+        uint256 tic = block.timestamp; // Start of auction
+        uint256 percentDecrease;
+        uint256 step;
+        uint256 testTime = 10 minutes;
+
+
+        /*** Extreme high collateral price ($50m) ***/
+
+        uint256 tolerance = 100000000; // Tolerance scales with price
+        uint256 top =       50000000 * RAY;
+
+        // 1.1234567890% decrease every 1 second
+        // TODO: Check if there's a cleaner way to do this. I was getting rational_const errors.
+        percentDecrease = RAY - 1.1234567890E27 / 100;
+        step = 1;
+        checkExpDecrease(calc, percentDecrease, step, top, tic, percentDecrease, testTime, tolerance);
+
+        // 2.1234567890% decrease every 1 second
+        percentDecrease = RAY - 2.1234567890E27 / 100;
+        step = 1;
+        checkExpDecrease(calc, percentDecrease, step, top, tic, percentDecrease, testTime, tolerance);
+
+        // 1.1234567890% decrease every 5 seconds
+        percentDecrease = RAY - 1.1234567890E27 / 100;
+        step = 5;
+        checkExpDecrease(calc, percentDecrease, step, top, tic, percentDecrease, testTime, tolerance);
+
+        // 2.1234567890% decrease every 5 seconds
+        percentDecrease = RAY - 2.1234567890E27 / 100;
+        step = 5;
+        checkExpDecrease(calc, percentDecrease, step, top, tic, percentDecrease, testTime, tolerance);
+
+        // 1.1234567890% decrease every 5 minutes
+        percentDecrease = RAY - 1.1234567890E27 / 100;
+        step = 5 minutes;
+        checkExpDecrease(calc, percentDecrease, step, top, tic, percentDecrease, testTime, tolerance);
+
+
+        /*** Extreme low collateral price ($0.0000001) ***/
+
+        tolerance = 1; // Lowest tolerance is 1e-27
+        top = 1 * RAY / 10000000;
+
+        // 1.1234567890% decrease every 1 second
+        percentDecrease = RAY - 1.1234567890E27 / 100;
+        step = 1;
+        checkExpDecrease(calc, percentDecrease, step, top, tic, percentDecrease, testTime, tolerance);
+
+        // 2.1234567890% decrease every 1 second
+        percentDecrease = RAY - 2.1234567890E27 / 100;
+        step = 1;
+        checkExpDecrease(calc, percentDecrease, step, top, tic, percentDecrease, testTime, tolerance);
+
+        // 1.1234567890% decrease every 5 seconds
+        percentDecrease = RAY - 1.1234567890E27 / 100;
+        step = 5;
+        checkExpDecrease(calc, percentDecrease, step, top, tic, percentDecrease, testTime, tolerance);
+
+        // 2.1234567890% decrease every 5 seconds
+        percentDecrease = RAY - 2.1234567890E27 / 100;
+        step = 5;
+        checkExpDecrease(calc, percentDecrease, step, top, tic, percentDecrease, testTime, tolerance);
+
+        // 1.1234567890% decrease every 5 minutes
+        percentDecrease = RAY - 1.1234567890E27 / 100;
+        step = 5 minutes;
+        checkExpDecrease(calc, percentDecrease, step, top, tic, percentDecrease, testTime, tolerance);
+    }
+
+    function test_continuous_exp_decrease() public {
+        ExponentialDecrease calc = new ExponentialDecrease();
+        uint256 tHalf = 900;
+        uint256 cut = 0.999230132966E27;  // ~15 half life, cut ~= e^(ln(1/2)/900)
+        calc.file("cut", cut);
+
+        uint256 top = 4000 * RAY;
+        uint256 expectedPrice = top;
+        uint256 tolerance = RAY / 1000;  // 0.001, i.e 0.1%
+        for (uint256 i = 0; i < 5; i++) {  // will cover initial value + four half-lives
+            assertEqWithinTolerance(calc.price(top, i*tHalf), expectedPrice, tolerance);
+            // each loop iteration advances one half-life, so expectedPrice decreases by a factor of 2
+            expectedPrice /= 2;
+        }
+    }
+
+    function test_linear_decrease() public {
+        hevm.warp(startTime);
+        LinearDecrease calc = new LinearDecrease();
+        calc.file(bytes32("tau"), 3600);
+
+        uint256 top = 1000 * RAY;
+        uint256 tic = block.timestamp; // Start of auction
+        uint256 price = calc.price(top, block.timestamp - tic);
+        assertEq(price, top);
+
+        hevm.warp(startTime + 360);                // 6min in,   1/10 done
+        price = calc.price(top, block.timestamp - tic);
+        assertEq(price, (1000 - 100) * RAY);
+
+        hevm.warp(startTime + 360 * 2);            // 12min in,  2/10 done
+        price = calc.price(top, block.timestamp - tic);
+        assertEq(price, (1000 - 100 * 2) * RAY);
+
+        hevm.warp(startTime + 360 * 3);            // 18min in,  3/10 done
+        price = calc.price(top, block.timestamp - tic);
+        assertEq(price, (1000 - 100 * 3) * RAY);
+
+        hevm.warp(startTime + 360 * 4);            // 24min in,  4/10 done
+        price = calc.price(top, block.timestamp - tic);
+        assertEq(price, (1000 - 100 * 4) * RAY);
+
+        hevm.warp(startTime + 360 * 5);            // 30min in,  5/10 done
+        price = calc.price(top, block.timestamp - tic);
+        assertEq(price, (1000 - 100 * 5) * RAY);
+
+        hevm.warp(startTime + 360 * 6);            // 36min in,  6/10 done
+        price = calc.price(top, block.timestamp - tic);
+        assertEq(price, (1000 - 100 * 6) * RAY);
+
+        hevm.warp(startTime + 360 * 7);            // 42min in,  7/10 done
+        price = calc.price(top, block.timestamp - tic);
+        assertEq(price, (1000 - 100 * 7) * RAY);
+
+        hevm.warp(startTime + 360 * 8);            // 48min in,  8/10 done
+        price = calc.price(top, block.timestamp - tic);
+        assertEq(price, (1000 - 100 * 8) * RAY);
+
+        hevm.warp(startTime + 360 * 9);            // 54min in,  9/10 done
+        price = calc.price(top, block.timestamp - tic);
+        assertEq(price, (1000 - 100 * 9) * RAY);
+
+        hevm.warp(startTime + 360 * 10);           // 60min in, 10/10 done
+        price = calc.price(top, block.timestamp - tic);
+        assertEq(price, 0);
+    }
+}

--- a/src/test/Clipper.t.sol
+++ b/src/test/Clipper.t.sol
@@ -1,0 +1,1722 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.13;
+
+import "ds-test/test.sol";
+import "ds-value/value.sol";
+
+import {Vat}     from "../Vat.sol";
+import {Spotter} from "../Spotter.sol";
+import {GemJoin} from "../GemJoin.sol";
+import {DaiJoin} from "../DaiJoin.sol";
+
+import {Clipper} from "../Clipper.sol";
+import "../Abaci.sol";
+import "../Dog.sol";
+
+import {MockToken} from "./mocks/Token.sol";
+
+contract VowMock {
+    function fess (uint256 due) public {}
+}
+
+interface Hevm {
+    function warp(uint256) external;
+    function store(address,bytes32,bytes32) external;
+}
+
+contract Exchange {
+
+    MockToken gold;
+    MockToken dai;
+    uint256 goldPrice;
+
+    constructor(MockToken gold_, MockToken dai_, uint256 goldPrice_) public {
+        gold = gold_;
+        dai = dai_;
+        goldPrice = goldPrice_;
+    }
+
+    function sellGold(uint256 goldAmt) external {
+        gold.transferFrom(msg.sender, address(this), goldAmt);
+        uint256 daiAmt = goldAmt * goldPrice / 1E18;
+        dai.transfer(msg.sender, daiAmt);
+    }
+}
+
+contract Trader {
+
+    Clipper clip;
+    Vat vat;
+    MockToken gold;
+    GemJoin goldJoin;
+    MockToken dai;
+    DaiJoin daiJoin;
+    Exchange exchange;
+
+    constructor(
+        Clipper clip_,
+        Vat vat_,
+        MockToken gold_,
+        GemJoin goldJoin_,
+        MockToken dai_,
+        DaiJoin daiJoin_,
+        Exchange exchange_
+    ) public {
+        clip = clip_;
+        vat = vat_;
+        gold = gold_;
+        goldJoin = goldJoin_;
+        dai = dai_;
+        daiJoin = daiJoin_;
+        exchange = exchange_;
+    }
+
+    function take(
+        uint256 id,
+        uint256 amt,
+        uint256 max,
+        address who,
+        bytes calldata data
+    )
+        external
+    {
+        clip.take({
+            id: id,
+            amt: amt,
+            max: max,
+            who: who,
+            data: data
+        });
+    }
+
+    function clipperCall(address sender, uint256 owe, uint256 slice, bytes calldata data)
+        external {
+        data;
+        goldJoin.exit(address(this), slice);
+        gold.approve(address(exchange));
+        exchange.sellGold(slice);
+        dai.approve(address(daiJoin));
+        vat.hope(address(clip));
+        daiJoin.join(sender, owe / 1E27);
+    }
+}
+
+contract Guy {
+    Clipper clip;
+
+    constructor(Clipper clip_) public {
+        clip = clip_;
+    }
+
+    function hope(address usr) public {
+        Vat(address(clip.vat())).hope(usr);
+    }
+
+    function take(
+        uint256 id,
+        uint256 amt,
+        uint256 max,
+        address who,
+        bytes calldata data
+    )
+        external
+    {
+        clip.take({
+            id: id,
+            amt: amt,
+            max: max,
+            who: who,
+            data: data
+        });
+    }
+
+    function bark(Dog dog, bytes32 ilk, address urn, address usr) external {
+        dog.bark(ilk, urn, usr);
+    }
+}
+
+contract BadGuy is Guy {
+
+    constructor(Clipper clip_) Guy(clip_) public {}
+
+    function clipperCall(address sender, uint256 owe, uint256 slice, bytes calldata data)
+        external {
+        sender; owe; slice; data;
+        clip.take({ // attempt reentrancy
+            id: 1,
+            amt: 25 ether,
+            max: 5 ether * 10E27,
+            who: address(this),
+            data: ""
+        });
+    }
+}
+
+contract RedoGuy is Guy {
+
+    constructor(Clipper clip_) Guy(clip_) public {}
+
+    function clipperCall(
+        address sender, uint256 owe, uint256 slice, bytes calldata data
+    ) external {
+        owe; slice; data;
+        clip.redo(1, sender);
+    }
+}
+
+contract KickGuy is Guy {
+
+    constructor(Clipper clip_) Guy(clip_) public {}
+
+    function clipperCall(
+        address sender, uint256 owe, uint256 slice, bytes calldata data
+    ) external {
+        sender; owe; slice; data;
+        clip.kick(1, 1, address(0), address(0));
+    }
+}
+
+contract FileUintGuy is Guy {
+
+    constructor(Clipper clip_) Guy(clip_) public {}
+
+    function clipperCall(
+        address sender, uint256 owe, uint256 slice, bytes calldata data
+    ) external {
+        sender; owe; slice; data;
+        clip.file("stopped", 1);
+    }
+}
+
+contract FileAddrGuy is Guy {
+
+    constructor(Clipper clip_) Guy(clip_) public {}
+
+    function clipperCall(
+        address sender, uint256 owe, uint256 slice, bytes calldata data
+    ) external {
+        sender; owe; slice; data;
+        clip.file("vow", address(123));
+    }
+}
+
+contract YankGuy is Guy {
+
+    constructor(Clipper clip_) Guy(clip_) public {}
+
+    function clipperCall(
+        address sender, uint256 owe, uint256 slice, bytes calldata data
+    ) external {
+        sender; owe; slice; data;
+        clip.yank(1);
+    }
+}
+
+contract PublicClip is Clipper {
+
+    constructor(address vat, address spot, address dog, bytes32 ilk) public Clipper(vat, spot, dog, ilk) {}
+
+    function add() public returns (uint256 id) {
+        id = ++kicks;
+        active.push(id);
+        sales[id].pos = active.length - 1;
+    }
+
+    function remove(uint256 id) public {
+        _remove(id);
+    }
+}
+
+contract ClipperTest is DSTest {
+    Hevm hevm;
+
+    Vat     vat;
+    Dog     dog;
+    Spotter spot;
+    VowMock vow;
+    DSValue pip;
+    MockToken gold;
+    GemJoin goldJoin;
+    MockToken dai;
+    DaiJoin daiJoin;
+
+    Clipper clip;
+
+    address me;
+    Exchange exchange;
+
+    address ali;
+    address bob;
+    address che;
+
+    uint256 WAD = 10 ** 18;
+    uint256 RAY = 10 ** 27;
+    uint256 RAD = 10 ** 45;
+
+    // CHEAT_CODE = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D
+    bytes20 constant CHEAT_CODE =
+        bytes20(uint160(uint256(keccak256('hevm cheat code'))));
+
+    bytes32 constant ilk = "gold";
+    uint256 constant goldPrice = 5 ether;
+
+    uint256 constant startTime = 604411200; // Used to avoid issues with `now`
+
+    function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require((z = x - y) <= x);
+    }
+
+    function _ink(bytes32 ilk_, address urn_) internal view returns (uint256) {
+        (uint256 ink_,) = vat.urns(ilk_, urn_);
+        return ink_;
+    }
+    function _art(bytes32 ilk_, address urn_) internal view returns (uint256) {
+        (,uint256 art_) = vat.urns(ilk_, urn_);
+        return art_;
+    }
+
+    modifier takeSetup {
+        uint256 pos;
+        uint256 tab;
+        uint256 lot;
+        address usr;
+        uint96  tic;
+        uint256 top;
+        uint256 ink;
+        uint256 art;
+
+        StairstepExponentialDecrease calc = new StairstepExponentialDecrease();
+        calc.file("cut",  RAY - ray(0.01 ether));  // 1% decrease
+        calc.file("step", 1);                      // Decrease every 1 second
+
+        clip.file("buf",  ray(1.25 ether));   // 25% Initial price buffer
+        clip.file("calc", address(calc));     // File price contract
+        clip.file("cusp", ray(0.3 ether));    // 70% drop before reset
+        clip.file("tail", 3600);              // 1 hour before reset
+
+        (ink, art) = vat.urns(ilk, me);
+        assertEq(ink, 40 ether);
+        assertEq(art, 100 ether);
+
+        assertEq(clip.kicks(), 0);
+        dog.bark(ilk, me, address(this));
+        assertEq(clip.kicks(), 1);
+
+        (ink, art) = vat.urns(ilk, me);
+        assertEq(ink, 0);
+        assertEq(art, 0);
+
+        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, rad(110 ether));
+        assertEq(lot, 40 ether);
+        assertEq(usr, me);
+        assertEq(uint256(tic), now);
+        assertEq(top, ray(5 ether)); // $4 plus 25%
+
+        assertEq(vat.gem(ilk, ali), 0);
+        assertEq(vat.dai(ali), rad(1000 ether));
+        assertEq(vat.gem(ilk, bob), 0);
+        assertEq(vat.dai(bob), rad(1000 ether));
+
+        _;
+    }
+
+    function ray(uint256 wad) internal pure returns (uint256) {
+        return wad * 10 ** 9;
+    }
+    function rad(uint256 wad) internal pure returns (uint256) {
+        return wad * 10 ** 27;
+    }
+    function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require(y == 0 || (z = x * y) / y == x);
+    }
+
+    function setUp() public {
+        hevm = Hevm(address(CHEAT_CODE));
+        hevm.warp(startTime);
+
+        me = address(this);
+
+        vat = new Vat();
+
+        spot = new Spotter(address(vat));
+        vat.rely(address(spot));
+
+        vow = new VowMock();
+        gold = new MockToken("GLD");
+        goldJoin = new GemJoin(address(vat), ilk, address(gold));
+        vat.rely(address(goldJoin));
+        dai = new MockToken("DAI");
+        daiJoin = new DaiJoin(address(vat), address(dai));
+        vat.suck(address(0), address(daiJoin), rad(1000 ether));
+        exchange = new Exchange(gold, dai, goldPrice * 11 / 10);
+
+        dai.mint(1000 ether);
+        dai.transfer(address(exchange), 1000 ether);
+        dai.setOwner(address(daiJoin));
+        gold.mint(1000 ether);
+        gold.transfer(address(goldJoin), 1000 ether);
+
+        dog = new Dog(address(vat));
+        dog.file("vow", address(vow));
+        vat.rely(address(dog));
+
+        vat.init(ilk);
+
+        vat.slip(ilk, me, 1000 ether);
+
+        pip = new DSValue();
+        pip.poke(bytes32(goldPrice)); // Spot = $2.5
+
+        spot.file(ilk, "pip", address(pip));
+        spot.file(ilk, "mat", ray(2 ether)); // 200% liquidation ratio for easier test calcs
+        spot.poke(ilk);
+
+        vat.file(ilk, "dust", rad(20 ether)); // $20 dust
+        vat.file(ilk, "line", rad(10000 ether));
+        vat.file("Line",      rad(10000 ether));
+
+        dog.file(ilk, "chop", 1.1 ether); // 10% chop
+        dog.file(ilk, "hole", rad(1000 ether));
+        dog.file("Hole", rad(1000 ether));
+
+        // dust and chop filed previously so clip.chost will be set correctly
+        clip = new Clipper(address(vat), address(spot), address(dog), ilk);
+        clip.upchost();
+        clip.rely(address(dog));
+
+        dog.file(ilk, "clip", address(clip));
+        dog.rely(address(clip));
+        vat.rely(address(clip));
+
+        assertEq(vat.gem(ilk, me), 1000 ether);
+        assertEq(vat.dai(me), 0);
+        vat.frob(ilk, me, me, me, 40 ether, 100 ether);
+        assertEq(vat.gem(ilk, me), 960 ether);
+        assertEq(vat.dai(me), rad(100 ether));
+
+        pip.poke(bytes32(uint256(4 ether))); // Spot = $2
+        spot.poke(ilk);          // Now unsafe
+
+        ali = address(new Guy(clip));
+        bob = address(new Guy(clip));
+        che = address(new Trader(clip, vat, gold, goldJoin, dai, daiJoin, exchange));
+
+        vat.hope(address(clip));
+        Guy(ali).hope(address(clip));
+        Guy(bob).hope(address(clip));
+
+        vat.suck(address(0), address(this), rad(1000 ether));
+        vat.suck(address(0), address(ali),  rad(1000 ether));
+        vat.suck(address(0), address(bob),  rad(1000 ether));
+    }
+
+    function test_change_dog() public {
+        assertTrue(address(clip.dog()) != address(123));
+        clip.file("dog", address(123));
+        assertEq(address(clip.dog()), address(123));
+    }
+
+    function test_get_chop() public {
+        uint256 chop = dog.chop(ilk);
+        (, uint256 chop2,,) = dog.ilks(ilk);
+        assertEq(chop, chop2);
+    }
+
+    function test_kick() public {
+        uint256 pos;
+        uint256 tab;
+        uint256 lot;
+        address usr;
+        uint96  tic;
+        uint256 top;
+        uint256 ink;
+        uint256 art;
+
+        clip.file("tip",  rad(100 ether)); // Flat fee of 100 DAI
+        clip.file("chip", 0);              // No linear increase
+
+        assertEq(clip.kicks(), 0);
+        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+        assertEq(usr, address(0));
+        assertEq(uint256(tic), 0);
+        assertEq(top, 0);
+        assertEq(vat.gem(ilk, me), 960 ether);
+        assertEq(vat.dai(ali), rad(1000 ether));
+        (ink, art) = vat.urns(ilk, me);
+        assertEq(ink, 40 ether);
+        assertEq(art, 100 ether);
+
+        Guy(ali).bark(dog, ilk, me, address(ali));
+
+        assertEq(clip.kicks(), 1);
+        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, rad(110 ether));
+        assertEq(lot, 40 ether);
+        assertEq(usr, me);
+        assertEq(uint256(tic), now);
+        assertEq(top, ray(4 ether));
+        assertEq(vat.gem(ilk, me), 960 ether);
+        assertEq(vat.dai(ali), rad(1100 ether)); // Paid "tip" amount of DAI for calling bark()
+        (ink, art) = vat.urns(ilk, me);
+        assertEq(ink, 0 ether);
+        assertEq(art, 0 ether);
+
+        pip.poke(bytes32(goldPrice)); // Spot = $2.5
+        spot.poke(ilk);          // Now safe
+
+        hevm.warp(startTime + 100);
+        vat.frob(ilk, me, me, me, 40 ether, 100 ether);
+
+        pip.poke(bytes32(uint256(4 ether))); // Spot = $2
+        spot.poke(ilk);          // Now unsafe
+
+        (pos, tab, lot, usr, tic, top) = clip.sales(2);
+        assertEq(pos, 0);
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+        assertEq(usr, address(0));
+        assertEq(uint256(tic), 0);
+        assertEq(top, 0);
+        assertEq(vat.gem(ilk, me), 920 ether);
+
+        clip.file(bytes32("buf"),  ray(1.25 ether)); // 25% Initial price buffer
+
+        clip.file("tip",  rad(100 ether)); // Flat fee of 100 DAI
+        clip.file("chip", 0.02 ether);     // Linear increase of 2% of tab
+
+        assertEq(vat.dai(bob), rad(1000 ether));
+
+        Guy(bob).bark(dog, ilk, me, address(bob));
+
+        assertEq(clip.kicks(), 2);
+        (pos, tab, lot, usr, tic, top) = clip.sales(2);
+        assertEq(pos, 1);
+        assertEq(tab, rad(110 ether));
+        assertEq(lot, 40 ether);
+        assertEq(usr, me);
+        assertEq(uint256(tic), now);
+        assertEq(top, ray(5 ether));
+        assertEq(vat.gem(ilk, me), 920 ether);
+        (ink, art) = vat.urns(ilk, me);
+        assertEq(ink, 0 ether);
+        assertEq(art, 0 ether);
+
+        assertEq(vat.dai(bob), rad(1000 ether) + rad(100 ether) + tab * 0.02 ether / WAD); // Paid (tip + due * chip) amount of DAI for calling bark()
+    }
+
+    function testFail_kick_zero_price() public {
+        pip.poke(bytes32(0));
+        dog.bark(ilk, me, address(this));
+    }
+
+    function testFail_redo_zero_price() public {
+        auctionResetSetup(1 hours);
+
+        pip.poke(bytes32(0));
+
+        hevm.warp(startTime + 1801 seconds);
+        (bool needsRedo,,,) = clip.getStatus(1);
+        assertTrue(needsRedo);
+        clip.redo(1, address(this));
+    }
+
+    function try_kick(uint256 tab, uint256 lot, address usr, address kpr) internal returns (bool ok) {
+        string memory sig = "kick(uint256,uint256,address,address)";
+        (ok,) = address(clip).call(abi.encodeWithSignature(sig, tab, lot, usr, kpr));
+    }
+
+    function test_kick_basic() public {
+        assertTrue(try_kick(1 ether, 2 ether, address(1), address(this)));
+    }
+
+    function test_kick_zero_tab() public {
+        assertTrue(!try_kick(0, 2 ether, address(1), address(this)));
+    }
+
+    function test_kick_zero_lot() public {
+        assertTrue(!try_kick(1 ether, 0, address(1), address(this)));
+    }
+
+    function test_kick_zero_usr() public {
+        assertTrue(!try_kick(1 ether, 2 ether, address(0), address(this)));
+    }
+
+    function try_bark(bytes32 ilk_, address urn_) internal returns (bool ok) {
+        string memory sig = "bark(bytes32,address,address)";
+        (ok,) = address(dog).call(abi.encodeWithSignature(sig, ilk_, urn_, address(this)));
+    }
+
+    function test_bark_not_leaving_dust() public {
+        uint256 pos;
+        uint256 tab;
+        uint256 lot;
+        address usr;
+        uint96  tic;
+        uint256 top;
+        uint256 ink;
+        uint256 art;
+
+        dog.file(ilk, "hole", rad(80 ether)); // Makes room = 80 WAD
+        dog.file(ilk, "chop", 1 ether); // 0% chop (for precise calculations)
+
+        assertEq(clip.kicks(), 0);
+        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+        assertEq(usr, address(0));
+        assertEq(uint256(tic), 0);
+        assertEq(top, 0);
+        assertEq(vat.gem(ilk, me), 960 ether);
+        (ink, art) = vat.urns(ilk, me);
+        assertEq(ink, 40 ether);
+        assertEq(art, 100 ether);
+
+        assertTrue(try_bark(ilk, me)); // art - dart = 100 - 80 = dust (= 20)
+
+        assertEq(clip.kicks(), 1);
+        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, rad(80 ether)); // No chop
+        assertEq(lot, 32 ether);
+        assertEq(usr, me);
+        assertEq(uint256(tic), now);
+        assertEq(top, ray(4 ether));
+        assertEq(vat.gem(ilk, me), 960 ether);
+        (ink, art) = vat.urns(ilk, me);
+        assertEq(ink, 8 ether);
+        assertEq(art, 20 ether);
+    }
+
+    function test_bark_not_leaving_dust_over_hole() public {
+        uint256 pos;
+        uint256 tab;
+        uint256 lot;
+        address usr;
+        uint96  tic;
+        uint256 top;
+        uint256 ink;
+        uint256 art;
+
+        dog.file(ilk, "hole", rad(80 ether) + ray(1 ether)); // Makes room = 80 WAD + 1 wei
+        dog.file(ilk, "chop", 1 ether); // 0% chop (for precise calculations)
+
+        assertEq(clip.kicks(), 0);
+        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+        assertEq(usr, address(0));
+        assertEq(uint256(tic), 0);
+        assertEq(top, 0);
+        assertEq(vat.gem(ilk, me), 960 ether);
+        (ink, art) = vat.urns(ilk, me);
+        assertEq(ink, 40 ether);
+        assertEq(art, 100 ether);
+
+        assertTrue(try_bark(ilk, me)); // art - dart = 100 - (80 + 1 wei) < dust (= 20) then the whole debt is taken
+
+        assertEq(clip.kicks(), 1);
+        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, rad(100 ether)); // No chop
+        assertEq(lot, 40 ether);
+        assertEq(usr, me);
+        assertEq(uint256(tic), now);
+        assertEq(top, ray(4 ether));
+        assertEq(vat.gem(ilk, me), 960 ether);
+        (ink, art) = vat.urns(ilk, me);
+        assertEq(ink, 0 ether);
+        assertEq(art, 0 ether);
+    }
+
+    function test_bark_not_leaving_dust_rate() public {
+        uint256 pos;
+        uint256 tab;
+        uint256 lot;
+        address usr;
+        uint96  tic;
+        uint256 top;
+        uint256 ink;
+        uint256 art;
+
+        vat.fold(ilk, address(vow), int256(ray(0.02 ether)));
+        (, uint256 rate,,,) = vat.ilks(ilk);
+        assertEq(rate, ray(1.02 ether));
+
+        dog.file(ilk, "hole", 100 * RAD);   // Makes room = 100 RAD
+        dog.file(ilk, "chop",   1 ether);   // 0% chop for precise calculations
+        vat.file(ilk, "dust",  20 * RAD);   // 20 DAI minimum Vault debt
+        clip.upchost();
+
+        assertEq(clip.kicks(), 0);
+        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+        assertEq(usr, address(0));
+        assertEq(uint256(tic), 0);
+        assertEq(top, 0);
+        assertEq(vat.gem(ilk, me), 960 ether);
+        (ink, art) = vat.urns(ilk, me);
+        assertEq(ink, 40 ether);
+        assertEq(art, 100 ether);  // Full debt is 102 DAI since rate = 1.02 * RAY
+
+        // (art - dart) * rate ~= 2 RAD < dust = 20 RAD
+        //   => remnant would be dusty, so a full liquidation occurs.
+        assertTrue(try_bark(ilk, me));
+
+        assertEq(clip.kicks(), 1);
+        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, mul(100 ether, rate));  // No chop
+        assertEq(lot, 40 ether);
+        assertEq(usr, me);
+        assertEq(uint256(tic), now);
+        assertEq(top, ray(4 ether));
+        assertEq(vat.gem(ilk, me), 960 ether);
+        (ink, art) = vat.urns(ilk, me);
+        assertEq(ink, 0);
+        assertEq(art, 0);
+    }
+
+    function test_bark_only_leaving_dust_over_hole_rate() public {
+        uint256 pos;
+        uint256 tab;
+        uint256 lot;
+        address usr;
+        uint96  tic;
+        uint256 top;
+        uint256 ink;
+        uint256 art;
+
+        vat.fold(ilk, address(vow), int256(ray(0.02 ether)));
+        (, uint256 rate,,,) = vat.ilks(ilk);
+        assertEq(rate, ray(1.02 ether));
+
+        dog.file(ilk, "hole", 816 * RAD / 10);  // Makes room = 81.6 RAD => dart = 80
+        dog.file(ilk, "chop",   1 ether);       // 0% chop for precise calculations
+        vat.file(ilk, "dust", 204 * RAD / 10);  // 20.4 DAI dust
+        clip.upchost();
+
+        assertEq(clip.kicks(), 0);
+        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+        assertEq(usr, address(0));
+        assertEq(uint256(tic), 0);
+        assertEq(top, 0);
+        assertEq(vat.gem(ilk, me), 960 ether);
+        (ink, art) = vat.urns(ilk, me);
+        assertEq(ink, 40 ether);
+        assertEq(art, 100 ether);
+
+        // (art - dart) * rate = 20.4 RAD == dust
+        //   => marginal threshold at which partial liquidation is acceptable
+        assertTrue(try_bark(ilk, me));
+
+        assertEq(clip.kicks(), 1);
+        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, 816 * RAD / 10);  // Equal to ilk.hole
+        assertEq(lot, 32 ether);
+        assertEq(usr, me);
+        assertEq(uint256(tic), now);
+        assertEq(top, ray(4 ether));
+        assertEq(vat.gem(ilk, me), 960 ether);
+        (ink, art) = vat.urns(ilk, me);
+        assertEq(ink, 8 ether);
+        assertEq(art, 20 ether);
+        (,,,, uint256 dust) = vat.ilks(ilk);
+        assertEq(art * rate, dust);
+    }
+
+    function test_Hole_hole() public {
+        assertEq(dog.Dirt(), 0);
+        (,,, uint256 dirt) = dog.ilks(ilk);
+        assertEq(dirt, 0);
+
+        dog.bark(ilk, me, address(this));
+
+        (, uint256 tab,,,,) = clip.sales(1);
+
+        assertEq(dog.Dirt(), tab);
+        (,,, dirt) = dog.ilks(ilk);
+        assertEq(dirt, tab);
+
+        bytes32 ilk2 = "silver";
+        Clipper clip2 = new Clipper(address(vat), address(spot), address(dog), ilk2);
+        clip2.upchost();
+        clip2.rely(address(dog));
+
+        dog.file(ilk2, "clip", address(clip2));
+        dog.file(ilk2, "chop", 1.1 ether);
+        dog.file(ilk2, "hole", rad(1000 ether));
+        dog.rely(address(clip2));
+
+        vat.init(ilk2);
+        vat.rely(address(clip2));
+        vat.file(ilk2, "line", rad(100 ether));
+
+        vat.slip(ilk2, me, 40 ether);
+
+        DSValue pip2 = new DSValue();
+        pip2.poke(bytes32(goldPrice)); // Spot = $2.5
+
+        spot.file(ilk2, "pip", address(pip2));
+        spot.file(ilk2, "mat", ray(2 ether));
+        spot.poke(ilk2);
+        vat.frob(ilk2, me, me, me, 40 ether, 100 ether);
+        pip2.poke(bytes32(uint256(4 ether))); // Spot = $2
+        spot.poke(ilk2);
+
+        dog.bark(ilk2, me, address(this));
+
+        (, uint256 tab2,,,,) = clip2.sales(1);
+
+        assertEq(dog.Dirt(), tab + tab2);
+        (,,, dirt) = dog.ilks(ilk);
+        (,,, uint256 dirt2) = dog.ilks(ilk2);
+        assertEq(dirt, tab);
+        assertEq(dirt2, tab2);
+    }
+
+    function test_partial_liquidation_Hole_limit() public {
+        dog.file("Hole", rad(75 ether));
+
+        assertEq(_ink(ilk, me), 40 ether);
+        assertEq(_art(ilk, me), 100 ether);
+
+        assertEq(dog.Dirt(), 0);
+        (,uint256 chop,, uint256 dirt) = dog.ilks(ilk);
+        assertEq(dirt, 0);
+
+        dog.bark(ilk, me, address(this));
+
+        (, uint256 tab, uint256 lot,,,) = clip.sales(1);
+
+        (, uint256 rate,,,) = vat.ilks(ilk);
+
+        assertEq(lot, 40 ether * (tab * WAD / rate / chop) / 100 ether);
+        assertEq(tab, rad(75 ether) - ray(0.2 ether)); // 0.2 RAY rounding error
+
+        assertEq(_ink(ilk, me), 40 ether - lot);
+        assertEq(_art(ilk, me), 100 ether - tab * WAD / rate / chop);
+
+        assertEq(dog.Dirt(), tab);
+        (,,, dirt) = dog.ilks(ilk);
+        assertEq(dirt, tab);
+    }
+
+    function test_partial_liquidation_hole_limit() public {
+        dog.file(ilk, "hole", rad(75 ether));
+
+        assertEq(_ink(ilk, me), 40 ether);
+        assertEq(_art(ilk, me), 100 ether);
+
+        assertEq(dog.Dirt(), 0);
+        (,uint256 chop,, uint256 dirt) = dog.ilks(ilk);
+        assertEq(dirt, 0);
+
+        dog.bark(ilk, me, address(this));
+
+        (, uint256 tab, uint256 lot,,,) = clip.sales(1);
+
+        (, uint256 rate,,,) = vat.ilks(ilk);
+
+        assertEq(lot, 40 ether * (tab * WAD / rate / chop) / 100 ether);
+        assertEq(tab, rad(75 ether) - ray(0.2 ether)); // 0.2 RAY rounding error
+
+        assertEq(_ink(ilk, me), 40 ether - lot);
+        assertEq(_art(ilk, me), 100 ether - tab * WAD / rate / chop);
+
+        assertEq(dog.Dirt(), tab);
+        (,,, dirt) = dog.ilks(ilk);
+        assertEq(dirt, tab);
+    }
+
+    function try_take(uint256 id, uint256 amt, uint256 max, address who, bytes memory data) internal returns (bool ok) {
+        string memory sig = "take(uint256,uint256,uint256,address,bytes)";
+        (ok,) = address(clip).call(abi.encodeWithSignature(sig, id, amt, max, who, data));
+    }
+
+    function test_take_zero_usr() public takeSetup {
+        // Auction id 2 is unpopulated.
+        (,,, address usr,,) = clip.sales(2);
+        assertEq(usr, address(0));
+        assertTrue(!try_take(2, 25 ether, ray(5 ether), address(ali), ""));
+    }
+
+    function test_take_over_tab() public takeSetup {
+        // Bid so owe (= 25 * 5 = 125 RAD) > tab (= 110 RAD)
+        // Readjusts slice to be tab/top = 25
+        Guy(ali).take({
+            id:  1,
+            amt: 25 ether,
+            max: ray(5 ether),
+            who: address(ali),
+            data: ""
+        });
+
+        assertEq(vat.gem(ilk, ali), 22 ether);  // Didn't take whole lot
+        assertEq(vat.dai(ali), rad(890 ether)); // Didn't pay more than tab (110)
+        assertEq(vat.gem(ilk, me),  978 ether); // 960 + (40 - 22) returned to usr
+
+        // Assert auction ends
+        (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+        assertEq(usr, address(0));
+        assertEq(uint256(tic), 0);
+        assertEq(top, 0);
+
+        assertEq(dog.Dirt(), 0);
+        (,,, uint256 dirt) = dog.ilks(ilk);
+        assertEq(dirt, 0);
+    }
+
+    function test_take_at_tab() public takeSetup {
+        // Bid so owe (= 22 * 5 = 110 RAD) == tab (= 110 RAD)
+        Guy(ali).take({
+            id:  1,
+            amt: 22 ether,
+            max: ray(5 ether),
+            who: address(ali),
+            data: ""
+        });
+
+        assertEq(vat.gem(ilk, ali), 22 ether);  // Didn't take whole lot
+        assertEq(vat.dai(ali), rad(890 ether)); // Paid full tab (110)
+        assertEq(vat.gem(ilk, me), 978 ether);  // 960 + (40 - 22) returned to usr
+
+        // Assert auction ends
+        (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+        assertEq(usr, address(0));
+        assertEq(uint256(tic), 0);
+        assertEq(top, 0);
+
+        assertEq(dog.Dirt(), 0);
+        (,,, uint256 dirt) = dog.ilks(ilk);
+        assertEq(dirt, 0);
+    }
+
+    function test_take_under_tab() public takeSetup {
+        // Bid so owe (= 11 * 5 = 55 RAD) < tab (= 110 RAD)
+        Guy(ali).take({
+            id:  1,
+            amt: 11 ether,     // Half of tab at $110
+            max: ray(5 ether),
+            who: address(ali),
+            data: ""
+        });
+
+        assertEq(vat.gem(ilk, ali), 11 ether);  // Didn't take whole lot
+        assertEq(vat.dai(ali), rad(945 ether)); // Paid half tab (55)
+        assertEq(vat.gem(ilk, me), 960 ether);  // Collateral not returned (yet)
+
+        // Assert auction DOES NOT end
+        (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, rad(55 ether));  // 110 - 5 * 11
+        assertEq(lot, 29 ether);       // 40 - 11
+        assertEq(usr, me);
+        assertEq(uint256(tic), now);
+        assertEq(top, ray(5 ether));
+
+        assertEq(dog.Dirt(), tab);
+        (,,, uint256 dirt) = dog.ilks(ilk);
+        assertEq(dirt, tab);
+    }
+
+    function test_take_full_lot_partial_tab() public takeSetup {
+        hevm.warp(now + 69);  // approx 50% price decline
+        // Bid to purchase entire lot less than tab (~2.5 * 40 ~= 100 < 110)
+        Guy(ali).take({
+            id:  1,
+            amt: 40 ether,     // purchase all collateral
+            max: ray(2.5 ether),
+            who: address(ali),
+            data: ""
+        });
+
+        assertEq(vat.gem(ilk, ali), 40 ether);  // Took entire lot
+        assertTrue(sub(vat.dai(ali), rad(900 ether)) < rad(0.1 ether));  // Paid about 100 ether
+        assertEq(vat.gem(ilk, me), 960 ether);  // Collateral not returned
+
+        // Assert auction ends
+        (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+        assertEq(usr, address(0));
+        assertEq(uint256(tic), 0);
+        assertEq(top, 0);
+
+        // All dirt should be cleared, since the auction has ended, even though < 100% of tab was collected
+        assertEq(dog.Dirt(), 0);
+        (,,, uint256 dirt) = dog.ilks(ilk);
+        assertEq(dirt, 0);
+    }
+
+    function testFail_take_bid_too_low() public takeSetup {
+        // Bid so max (= 4) < price (= top = 5) (fails with "Clipper/too-expensive")
+        Guy(ali).take({
+            id:  1,
+            amt: 22 ether,
+            max: ray(4 ether),
+            who: address(ali),
+            data: ""
+        });
+    }
+
+    function test_take_bid_recalculates_due_to_chost_check() public takeSetup {
+        (, uint256 tab, uint256 lot,,,) = clip.sales(1);
+        assertEq(tab, rad(110 ether));
+        assertEq(lot, 40 ether);
+
+        (, uint256 price,uint256 _lot, uint256 _tab) = clip.getStatus(1);
+        assertEq(_lot, lot);
+        assertEq(_tab, tab);
+        assertEq(price, ray(5 ether));
+
+        // Bid for an amount that would leave less than chost remaining tab--bid will be decreased
+        // to leave tab == chost post-execution.
+        Guy(ali).take({
+            id:  1,
+            amt: 18 * WAD,  // Costs 90 DAI at current price; 110 - 90 == 20 < 22 == chost
+            max: ray(5 ether),
+            who: address(ali),
+            data: ""
+        });
+
+        (, tab, lot,,,) = clip.sales(1);
+        assertEq(tab, clip.chost());
+        assertEq(lot, 40 ether - (110 * RAD - clip.chost()) / price);
+    }
+
+    function test_take_bid_avoids_recalculate_due_no_more_lot() public takeSetup {
+        hevm.warp(now + 60); // Reducing the price
+
+        (, uint256 tab, uint256 lot,,,) = clip.sales(1);
+        assertEq(tab, rad(110 ether));
+        assertEq(lot, 40 ether);
+
+        (, uint256 price,,) = clip.getStatus(1);
+        assertEq(price, 2735783211953807380973706855); // 2.73 RAY
+
+        // Bid so owe (= (22 - 1wei) * 5 = 110 RAD - 1) < tab (= 110 RAD)
+        // 1 < 20 RAD => owe = 110 RAD - 20 RAD
+        Guy(ali).take({
+            id:  1,
+            amt: 40 ether,
+            max: ray(2.8 ether),
+            who: address(ali),
+            data: ""
+        });
+
+        // 40 * 2.73 = 109.42...
+        // It means a very low amount of tab (< dust) would remain but doesn't matter
+        // as the auction is finished because there isn't more lot
+        (, tab, lot,,,) = clip.sales(1);
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+    }
+
+    function test_take_bid_fails_no_partial_allowed() public takeSetup {
+        (, uint256 price,,) = clip.getStatus(1);
+        assertEq(price, ray(5 ether));
+
+        clip.take({
+            id:  1,
+            amt: 17.6 ether,
+            max: ray(5 ether),
+            who: address(this),
+            data: ""
+        });
+
+        (, uint256 tab, uint256 lot,,,) = clip.sales(1);
+        assertEq(tab, rad(22 ether));
+        assertEq(lot, 22.4 ether);
+        assertTrue(!(tab > clip.chost()));
+
+        assertTrue(!try_take({
+            id:  1,
+            amt: 1 ether,  // partial purchase attempt when !(tab > chost)
+            max: ray(5 ether),
+            who: address(this),
+            data: ""
+        }));
+
+        clip.take({
+            id:  1,
+            amt: tab / price, // This time take the whole tab
+            max: ray(5 ether),
+            who: address(this),
+            data: ""
+        });
+    }
+
+    function test_take_multiple_bids_different_prices() public takeSetup {
+        uint256 pos;
+        uint256 tab;
+        uint256 lot;
+        address usr;
+        uint96  tic;
+        uint256 top;
+
+        // Bid so owe (= 10 * 5 = 50 RAD) < tab (= 110 RAD)
+        Guy(ali).take({
+            id:  1,
+            amt: 10 ether,
+            max: ray(5 ether),
+            who: address(ali),
+            data: ""
+        });
+
+        assertEq(vat.gem(ilk, ali), 10 ether);  // Didn't take whole lot
+        assertEq(vat.dai(ali), rad(950 ether)); // Paid some tab (50)
+        assertEq(vat.gem(ilk, me), 960 ether);  // Collateral not returned (yet)
+
+        // Assert auction DOES NOT end
+        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, rad(60 ether));  // 110 - 5 * 10
+        assertEq(lot, 30 ether);       // 40 - 10
+        assertEq(usr, me);
+        assertEq(uint256(tic), now);
+        assertEq(top, ray(5 ether));
+
+        hevm.warp(now + 30);
+
+        (, uint256 _price, uint256 _lot,) = clip.getStatus(1);
+        Guy(bob).take({
+            id:  1,
+            amt: _lot,     // Buy the rest of the lot
+            max: ray(_price), // 5 * 0.99 ** 30 = 3.698501866941401 RAY => max > price
+            who: address(bob),
+            data: ""
+        });
+
+        // Assert auction is over
+        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, 0);
+        assertEq(lot, 0 * WAD);
+        assertEq(usr, address(0));
+        assertEq(uint256(tic), 0);
+        assertEq(top, 0);
+
+        uint256 expectedGem = (RAY * 60 ether) / _price;  // tab / price
+        assertEq(vat.gem(ilk, bob), expectedGem);         // Didn't take whole lot
+        assertEq(vat.dai(bob), rad(940 ether));           // Paid rest of tab (60)
+
+        uint256 lotReturn = 30 ether - expectedGem;         // lot - loaf.tab / max = 15
+        assertEq(vat.gem(ilk, me), 960 ether + lotReturn);  // Collateral returned (10 WAD)
+    }
+
+    function auctionResetSetup(uint256 tau) internal {
+        LinearDecrease calc = new LinearDecrease();
+        calc.file(bytes32("tau"), tau);       // tau hours till zero is reached (used to test tail)
+
+        vat.file(ilk, "dust", rad(20 ether)); // $20 dust
+
+        clip.file("buf",  ray(1.25 ether));   // 25% Initial price buffer
+        clip.file("calc", address(calc));     // File price contract
+        clip.file("cusp", ray(0.5 ether));    // 50% drop before reset
+        clip.file("tail", 3600);              // 1 hour before reset
+
+        assertEq(clip.kicks(), 0);
+        dog.bark(ilk, me, address(this));
+        assertEq(clip.kicks(), 1);
+    }
+
+    function try_redo(uint256 id, address kpr) internal returns (bool ok) {
+        string memory sig = "redo(uint256,address)";
+        (ok,) = address(clip).call(abi.encodeWithSignature(sig, id, kpr));
+    }
+
+    function test_auction_reset_tail() public {
+        auctionResetSetup(10 hours); // 10 hours till zero is reached (used to test tail)
+
+        pip.poke(bytes32(uint256(3 ether))); // Spot = $1.50 (update price before reset is called)
+
+        (,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
+        assertEq(uint256(ticBefore), startTime);
+        assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
+
+        hevm.warp(startTime + 3600 seconds);
+        (bool needsRedo,,,) = clip.getStatus(1);
+        assertTrue(!needsRedo);
+        assertTrue(!try_redo(1, address(this)));
+        hevm.warp(startTime + 3601 seconds);
+        (needsRedo,,,) = clip.getStatus(1);
+        assertTrue(needsRedo);
+        assertTrue(try_redo(1, address(this)));
+
+        (,,,, uint96 ticAfter, uint256 topAfter) = clip.sales(1);
+        assertEq(uint256(ticAfter), startTime + 3601 seconds);     // (now)
+        assertEq(topAfter, ray(3.75 ether)); // $3 spot + 25% buffer = $5 (used most recent OSM price)
+    }
+
+    function test_auction_reset_cusp() public {
+        auctionResetSetup(1 hours); // 1 hour till zero is reached (used to test cusp)
+
+        pip.poke(bytes32(uint256(3 ether))); // Spot = $1.50 (update price before reset is called)
+
+        (,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
+        assertEq(uint256(ticBefore), startTime);
+        assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
+
+        hevm.warp(startTime + 1800 seconds);
+        (bool needsRedo,,,) = clip.getStatus(1);
+        assertTrue(!needsRedo);
+        assertTrue(!try_redo(1, address(this)));
+        hevm.warp(startTime + 1801 seconds);
+        (needsRedo,,,) = clip.getStatus(1);
+        assertTrue(needsRedo);
+        assertTrue(try_redo(1, address(this)));
+
+        (,,,, uint96 ticAfter, uint256 topAfter) = clip.sales(1);
+        assertEq(uint256(ticAfter), startTime + 1801 seconds);     // (now)
+        assertEq(topAfter, ray(3.75 ether)); // $3 spot + 25% buffer = $3.75 (used most recent OSM price)
+    }
+
+    function test_auction_reset_tail_twice() public {
+        auctionResetSetup(10 hours); // 10 hours till zero is reached (used to test tail)
+
+        hevm.warp(startTime + 3601 seconds);
+        clip.redo(1, address(this));
+
+        assertTrue(!try_redo(1, address(this)));
+    }
+
+    function test_auction_reset_cusp_twice() public {
+        auctionResetSetup(1 hours); // 1 hour till zero is reached (used to test cusp)
+
+        hevm.warp(startTime + 1801 seconds); // Price goes below 50% "cusp" after 30min01sec
+        clip.redo(1, address(this));
+
+        assertTrue(!try_redo(1, address(this)));
+    }
+
+    function test_redo_zero_usr() public {
+        // Can't reset a non-existent auction.
+        assertTrue(!try_redo(1, address(this)));
+    }
+
+    function test_setBreaker() public {
+        clip.file("stopped", 1);
+        assertEq(clip.stopped(), 1);
+        clip.file("stopped", 2);
+        assertEq(clip.stopped(), 2);
+        clip.file("stopped", 3);
+        assertEq(clip.stopped(), 3);
+        clip.file("stopped", 0);
+        assertEq(clip.stopped(), 0);
+    }
+
+    function test_stopped_kick() public {
+        uint256 pos;
+        uint256 tab;
+        uint256 lot;
+        address usr;
+        uint96  tic;
+        uint256 top;
+        uint256 ink;
+        uint256 art;
+
+        assertEq(clip.kicks(), 0);
+        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+        assertEq(usr, address(0));
+        assertEq(uint256(tic), 0);
+        assertEq(top, 0);
+        assertEq(vat.gem(ilk, me), 960 ether);
+        (ink, art) = vat.urns(ilk, me);
+        assertEq(ink, 40 ether);
+        assertEq(art, 100 ether);
+
+        // Any level of stoppage prevents kicking.
+        clip.file("stopped", 1);
+        assertTrue(!try_bark(ilk, me));
+
+        clip.file("stopped", 2);
+        assertTrue(!try_bark(ilk, me));
+
+        clip.file("stopped", 3);
+        assertTrue(!try_bark(ilk, me));
+
+        clip.file("stopped", 0);
+        assertTrue(try_bark(ilk, me));
+    }
+
+    // At a stopped == 1 we are ok to take
+    function test_stopped_1_take() public takeSetup {
+        clip.file("stopped", 1);
+        // Bid so owe (= 25 * 5 = 125 RAD) > tab (= 110 RAD)
+        // Readjusts slice to be tab/top = 25
+        Guy(ali).take({
+            id:  1,
+            amt: 25 ether,
+            max: ray(5 ether),
+            who: address(ali),
+            data: ""
+        });
+    }
+
+    function test_stopped_2_take() public takeSetup {
+        clip.file("stopped", 2);
+        // Bid so owe (= 25 * 5 = 125 RAD) > tab (= 110 RAD)
+        // Readjusts slice to be tab/top = 25
+        Guy(ali).take({
+            id:  1,
+            amt: 25 ether,
+            max: ray(5 ether),
+            who: address(ali),
+            data: ""
+        });
+    }
+
+    function testFail_stopped_3_take() public takeSetup {
+        clip.file("stopped", 3);
+        // Bid so owe (= 25 * 5 = 125 RAD) > tab (= 110 RAD)
+        // Readjusts slice to be tab/top = 25
+        Guy(ali).take({
+            id:  1,
+            amt: 25 ether,
+            max: ray(5 ether),
+            who: address(ali),
+            data: ""
+        });
+    }
+
+    function test_stopped_1_auction_reset_tail() public {
+        auctionResetSetup(10 hours); // 10 hours till zero is reached (used to test tail)
+
+        clip.file("stopped", 1);
+
+        pip.poke(bytes32(uint256(3 ether))); // Spot = $1.50 (update price before reset is called)
+
+        (,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
+        assertEq(uint256(ticBefore), startTime);
+        assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
+
+        hevm.warp(startTime + 3600 seconds);
+        assertTrue(!try_redo(1, address(this)));
+        hevm.warp(startTime + 3601 seconds);
+        assertTrue(try_redo(1, address(this)));
+
+        (,,,, uint96 ticAfter, uint256 topAfter) = clip.sales(1);
+        assertEq(uint256(ticAfter), startTime + 3601 seconds);     // (now)
+        assertEq(topAfter, ray(3.75 ether)); // $3 spot + 25% buffer = $5 (used most recent OSM price)
+    }
+
+    function test_stopped_2_auction_reset_tail() public {
+        auctionResetSetup(10 hours); // 10 hours till zero is reached (used to test tail)
+
+        clip.file("stopped", 2);
+
+        pip.poke(bytes32(uint256(3 ether))); // Spot = $1.50 (update price before reset is called)
+
+        (,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
+        assertEq(uint256(ticBefore), startTime);
+        assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
+
+        hevm.warp(startTime + 3601 seconds);
+        (bool needsRedo,,,) = clip.getStatus(1);
+        assertTrue(needsRedo);  // Redo possible if circuit breaker not set
+        assertTrue(!try_redo(1, address(this)));  // Redo fails because of circuit breaker
+    }
+
+    function test_stopped_3_auction_reset_tail() public {
+        auctionResetSetup(10 hours); // 10 hours till zero is reached (used to test tail)
+
+        clip.file("stopped", 3);
+
+        pip.poke(bytes32(uint256(3 ether))); // Spot = $1.50 (update price before reset is called)
+
+        (,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
+        assertEq(uint256(ticBefore), startTime);
+        assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
+
+        hevm.warp(startTime + 3601 seconds);
+        (bool needsRedo,,,) = clip.getStatus(1);
+        assertTrue(needsRedo);  // Redo possible if circuit breaker not set
+        assertTrue(!try_redo(1, address(this)));  // Redo fails because of circuit breaker
+    }
+
+    function test_redo_incentive() public takeSetup {
+        clip.file("tip",  rad(100 ether)); // Flat fee of 100 DAI
+        clip.file("chip", 0);              // No linear increase
+
+        (, uint256 tab, uint256 lot,,,) = clip.sales(1);
+
+        assertEq(tab, rad(110 ether));
+        assertEq(lot, 40 ether);
+
+        hevm.warp(now + 300);
+        clip.redo(1, address(123));
+        assertEq(vat.dai(address(123)), clip.tip());
+
+        clip.file("chip", 0.02 ether);     // Reward 2% of tab
+        hevm.warp(now + 300);
+        clip.redo(1, address(234));
+        assertEq(vat.dai(address(234)), clip.tip() + clip.chip() * tab / WAD);
+
+        clip.file("tip", 0); // No more flat fee
+        hevm.warp(now + 300);
+        clip.redo(1, address(345));
+        assertEq(vat.dai(address(345)), clip.chip() * tab / WAD);
+
+        vat.file(ilk, "dust", rad(100 ether) + 1); // ensure wmul(dust, chop) > 110 DAI (tab)
+        clip.upchost();
+        assertEq(clip.chost(), 110 * RAD + 1);
+
+        hevm.warp(now + 300);
+        clip.redo(1, address(456));
+        assertEq(vat.dai(address(456)), 0);
+
+        // Set dust so that wmul(dust, chop) is well below tab to check the dusty lot case.
+        vat.file(ilk, "dust", rad(20 ether)); // $20 dust
+        clip.upchost();
+        assertEq(clip.chost(), 22 * RAD);
+
+        hevm.warp(now + 100); // Reducing the price
+
+        (, uint256 price,,) = clip.getStatus(1);
+        assertEq(price, 1830161706366147524653080130); // 1.83 RAY
+
+        clip.take({
+            id:  1,
+            amt: 38 ether,
+            max: ray(5 ether),
+            who: address(this),
+            data: ""
+        });
+
+        (, tab, lot,,,) = clip.sales(1);
+
+        assertEq(tab, rad(110 ether) - 38 ether * price); // > 22 DAI chost
+        // When auction is reset the current price of lot
+        // is calculated from oracle price ($4) to see if dusty
+        assertEq(lot, 2 ether); // (2 * $4) < $20 quivalent (dusty collateral)
+
+        hevm.warp(now + 300);
+        clip.redo(1, address(567));
+        assertEq(vat.dai(address(567)), 0);
+    }
+
+    function test_incentive_max_values() public {
+        clip.file("chip", 2 ** 64 - 1);
+        clip.file("tip", 2 ** 192 - 1);
+
+        assertEq(uint256(clip.chip()), uint256(18.446744073709551615 * 10 ** 18));
+        assertEq(uint256(clip.tip()), uint256(6277101735386.680763835789423207666416102355444464034512895 * 10 ** 45));
+
+        clip.file("chip", 2 ** 64);
+        clip.file("tip", 2 ** 192);
+
+        assertEq(uint256(clip.chip()), 0);
+        assertEq(uint256(clip.tip()), 0);
+    }
+
+    function test_Clipper_yank() public takeSetup {
+        uint256 preGemBalance = vat.gem(ilk, address(this));
+        (,, uint256 origLot,,,) = clip.sales(1);
+
+        uint startGas = gasleft();
+        clip.yank(1);
+        uint endGas = gasleft();
+        emit log_named_uint("yank gas", startGas - endGas);
+
+        // Assert that the auction was deleted.
+        (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+        assertEq(usr, address(0));
+        assertEq(uint256(tic), 0);
+        assertEq(top, 0);
+
+        // Assert that callback to clear dirt was successful.
+        assertEq(dog.Dirt(), 0);
+        (,,, uint256 dirt) = dog.ilks(ilk);
+        assertEq(dirt, 0);
+
+        // Assert transfer of gem.
+        assertEq(vat.gem(ilk, address(this)), preGemBalance + origLot);
+    }
+
+    function test_remove_id() public {
+        PublicClip pclip = new PublicClip(address(vat), address(spot), address(dog), "gold");
+        uint256 pos;
+
+        pclip.add();
+        pclip.add();
+        uint256 id = pclip.add();
+        pclip.add();
+        pclip.add();
+
+        // [1,2,3,4,5]
+        assertEq(pclip.count(), 5);   // 5 elements added
+        assertEq(pclip.active(0), 1);
+        assertEq(pclip.active(1), 2);
+        assertEq(pclip.active(2), 3);
+        assertEq(pclip.active(3), 4);
+        assertEq(pclip.active(4), 5);
+
+        pclip.remove(id);
+
+        // [1,2,5,4]
+        assertEq(pclip.count(), 4);
+        assertEq(pclip.active(0), 1);
+        assertEq(pclip.active(1), 2);
+        assertEq(pclip.active(2), 5);  // Swapped last for middle
+        (pos,,,,,) = pclip.sales(5);
+        assertEq(pos, 2);
+        assertEq(pclip.active(3), 4);
+
+        pclip.remove(4);
+
+        // [1,2,5]
+        assertEq(pclip.count(), 3);
+
+        (pos,,,,,) = pclip.sales(1);
+        assertEq(pos, 0); // Sale 1 in slot 0
+        assertEq(pclip.active(0), 1);
+
+        (pos,,,,,) = pclip.sales(2);
+        assertEq(pos, 1); // Sale 2 in slot 1
+        assertEq(pclip.active(1), 2);
+
+        (pos,,,,,) = pclip.sales(5);
+        assertEq(pos, 2); // Sale 5 in slot 2
+        assertEq(pclip.active(2), 5); // Final element removed
+
+        (pos,,,,,) = pclip.sales(4);
+        assertEq(pos, 0); // Sale 4 was deleted. Returns 0
+    }
+
+    function testFail_id_out_of_range() public {
+        PublicClip pclip = new PublicClip(address(vat), address(spot), address(dog), "gold");
+
+        pclip.add();
+        pclip.add();
+
+        pclip.active(9); // Fail because id is out of range
+    }
+
+    function testFail_not_enough_dai() public takeSetup {
+        Guy(che).take({
+            id:  1,
+            amt: 25 ether,
+            max: ray(5 ether),
+            who: address(che),
+            data: ""
+        });
+    }
+
+    function test_flashsale() public takeSetup {
+        assertEq(vat.dai(che), 0);
+        assertEq(dai.balanceOf(che), 0);
+        Guy(che).take({
+            id:  1,
+            amt: 25 ether,
+            max: ray(5 ether),
+            who: address(che),
+            data: "hey"
+        });
+        assertEq(vat.dai(che), 0);
+        assertTrue(dai.balanceOf(che) > 0); // Che turned a profit
+    }
+
+    function testFail_reentrancy_take() public takeSetup {
+        BadGuy usr = new BadGuy(clip);
+        usr.hope(address(clip));
+        vat.suck(address(0), address(usr),  rad(1000 ether));
+
+        usr.take({
+            id: 1,
+            amt: 25 ether,
+            max: ray(5 ether),
+            who: address(usr),
+            data: "hey"
+        });
+    }
+
+    function testFail_reentrancy_redo() public takeSetup {
+        RedoGuy usr = new RedoGuy(clip);
+        usr.hope(address(clip));
+        vat.suck(address(0), address(usr),  rad(1000 ether));
+
+        usr.take({
+            id: 1,
+            amt: 25 ether,
+            max: ray(5 ether),
+            who: address(usr),
+            data: "hey"
+        });
+    }
+
+    function testFail_reentrancy_kick() public takeSetup {
+        KickGuy usr = new KickGuy(clip);
+        usr.hope(address(clip));
+        vat.suck(address(0), address(usr),  rad(1000 ether));
+        clip.rely(address(usr));
+
+        usr.take({
+            id: 1,
+            amt: 25 ether,
+            max: ray(5 ether),
+            who: address(usr),
+            data: "hey"
+        });
+    }
+
+    function testFail_reentrancy_file_uint() public takeSetup {
+        FileUintGuy usr = new FileUintGuy(clip);
+        usr.hope(address(clip));
+        vat.suck(address(0), address(usr),  rad(1000 ether));
+        clip.rely(address(usr));
+
+        usr.take({
+            id: 1,
+            amt: 25 ether,
+            max: ray(5 ether),
+            who: address(usr),
+            data: "hey"
+        });
+    }
+
+    function testFail_reentrancy_file_addr() public takeSetup {
+        FileAddrGuy usr = new FileAddrGuy(clip);
+        usr.hope(address(clip));
+        vat.suck(address(0), address(usr),  rad(1000 ether));
+        clip.rely(address(usr));
+
+        usr.take({
+            id: 1,
+            amt: 25 ether,
+            max: ray(5 ether),
+            who: address(usr),
+            data: "hey"
+        });
+    }
+
+    function testFail_reentrancy_yank() public takeSetup {
+        YankGuy usr = new YankGuy(clip);
+        usr.hope(address(clip));
+        vat.suck(address(0), address(usr),  rad(1000 ether));
+        clip.rely(address(usr));
+
+        usr.take({
+            id: 1,
+            amt: 25 ether,
+            max: ray(5 ether),
+            who: address(usr),
+            data: "hey"
+        });
+    }
+
+    function testFail_take_impersonation() public takeSetup { // should fail, but works
+        Guy usr = new Guy(clip);
+        usr.take({
+            id: 1,
+            amt: 99999999999999 ether,
+            max: ray(99999999999999 ether),
+            who: address(ali),
+            data: ""
+        });
+    }
+
+    function test_gas_bark_kick() public {
+        // Assertions to make sure setup is as expected.
+        assertEq(clip.kicks(), 0);
+        (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+        assertEq(usr, address(0));
+        assertEq(uint256(tic), 0);
+        assertEq(top, 0);
+        assertEq(vat.gem(ilk, me), 960 ether);
+        assertEq(vat.dai(ali), rad(1000 ether));
+        (uint256 ink, uint256 art) = vat.urns(ilk, me);
+        assertEq(ink, 40 ether);
+        assertEq(art, 100 ether);
+
+        uint256 preGas = gasleft();
+        Guy(ali).bark(dog, ilk, me, address(ali));
+        uint256 diffGas = preGas - gasleft();
+        log_named_uint("bark with kick gas", diffGas);
+    }
+
+    function test_gas_partial_take() public takeSetup {
+        uint256 preGas = gasleft();
+        // Bid so owe (= 11 * 5 = 55 RAD) < tab (= 110 RAD)
+        Guy(ali).take({
+            id:  1,
+            amt: 11 ether,     // Half of tab at $110
+            max: ray(5 ether),
+            who: address(ali),
+            data: ""
+        });
+        uint256 diffGas = preGas - gasleft();
+        log_named_uint("partial take gas", diffGas);
+
+        assertEq(vat.gem(ilk, ali), 11 ether);  // Didn't take whole lot
+        assertEq(vat.dai(ali), rad(945 ether)); // Paid half tab (55)
+        assertEq(vat.gem(ilk, me), 960 ether);  // Collateral not returned (yet)
+
+        // Assert auction DOES NOT end
+        (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, rad(55 ether));  // 110 - 5 * 11
+        assertEq(lot, 29 ether);       // 40 - 11
+        assertEq(usr, me);
+        assertEq(uint256(tic), now);
+        assertEq(top, ray(5 ether));
+    }
+
+    function test_gas_full_take() public takeSetup {
+        uint256 preGas = gasleft();
+        // Bid so owe (= 25 * 5 = 125 RAD) > tab (= 110 RAD)
+        // Readjusts slice to be tab/top = 25
+        Guy(ali).take({
+            id:  1,
+            amt: 25 ether,
+            max: ray(5 ether),
+            who: address(ali),
+            data: ""
+        });
+        uint256 diffGas = preGas - gasleft();
+        log_named_uint("full take gas", diffGas);
+
+        assertEq(vat.gem(ilk, ali), 22 ether);  // Didn't take whole lot
+        assertEq(vat.dai(ali), rad(890 ether)); // Didn't pay more than tab (110)
+        assertEq(vat.gem(ilk, me),  978 ether); // 960 + (40 - 22) returned to usr
+
+        // Assert auction ends
+        (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+        assertEq(usr, address(0));
+        assertEq(uint256(tic), 0);
+        assertEq(top, 0);
+    }
+}

--- a/src/test/Clipper.t.sol
+++ b/src/test/Clipper.t.sol
@@ -31,7 +31,7 @@ contract Exchange {
     MockToken dai;
     uint256 goldPrice;
 
-    constructor(MockToken gold_, MockToken dai_, uint256 goldPrice_) public {
+    constructor(MockToken gold_, MockToken dai_, uint256 goldPrice_) {
         gold = gold_;
         dai = dai_;
         goldPrice = goldPrice_;
@@ -62,7 +62,7 @@ contract Trader {
         MockToken dai_,
         DaiJoin daiJoin_,
         Exchange exchange_
-    ) public {
+    ) {
         clip = clip_;
         vat = vat_;
         gold = gold_;
@@ -105,7 +105,7 @@ contract Trader {
 contract Guy {
     Clipper clip;
 
-    constructor(Clipper clip_) public {
+    constructor(Clipper clip_) {
         clip = clip_;
     }
 
@@ -138,7 +138,7 @@ contract Guy {
 
 contract BadGuy is Guy {
 
-    constructor(Clipper clip_) Guy(clip_) public {}
+    constructor(Clipper clip_) Guy(clip_) {}
 
     function clipperCall(address sender, uint256 owe, uint256 slice, bytes calldata data)
         external {
@@ -155,7 +155,7 @@ contract BadGuy is Guy {
 
 contract RedoGuy is Guy {
 
-    constructor(Clipper clip_) Guy(clip_) public {}
+    constructor(Clipper clip_) Guy(clip_) {}
 
     function clipperCall(
         address sender, uint256 owe, uint256 slice, bytes calldata data
@@ -167,7 +167,7 @@ contract RedoGuy is Guy {
 
 contract KickGuy is Guy {
 
-    constructor(Clipper clip_) Guy(clip_) public {}
+    constructor(Clipper clip_) Guy(clip_) {}
 
     function clipperCall(
         address sender, uint256 owe, uint256 slice, bytes calldata data
@@ -179,7 +179,7 @@ contract KickGuy is Guy {
 
 contract FileUintGuy is Guy {
 
-    constructor(Clipper clip_) Guy(clip_) public {}
+    constructor(Clipper clip_) Guy(clip_) {}
 
     function clipperCall(
         address sender, uint256 owe, uint256 slice, bytes calldata data
@@ -191,7 +191,7 @@ contract FileUintGuy is Guy {
 
 contract FileAddrGuy is Guy {
 
-    constructor(Clipper clip_) Guy(clip_) public {}
+    constructor(Clipper clip_) Guy(clip_) {}
 
     function clipperCall(
         address sender, uint256 owe, uint256 slice, bytes calldata data
@@ -203,7 +203,7 @@ contract FileAddrGuy is Guy {
 
 contract YankGuy is Guy {
 
-    constructor(Clipper clip_) Guy(clip_) public {}
+    constructor(Clipper clip_) Guy(clip_) {}
 
     function clipperCall(
         address sender, uint256 owe, uint256 slice, bytes calldata data
@@ -215,7 +215,7 @@ contract YankGuy is Guy {
 
 contract PublicClip is Clipper {
 
-    constructor(address vat, address spot, address dog, bytes32 ilk) public Clipper(vat, spot, dog, ilk) {}
+    constructor(address vat, address spot, address dog, bytes32 ilk) Clipper(vat, spot, dog, ilk) {}
 
     function add() public returns (uint256 id) {
         id = ++kicks;
@@ -312,7 +312,7 @@ contract ClipperTest is DSTest {
         assertEq(tab, rad(110 ether));
         assertEq(lot, 40 ether);
         assertEq(usr, me);
-        assertEq(uint256(tic), now);
+        assertEq(uint256(tic), block.timestamp);
         assertEq(top, ray(5 ether)); // $4 plus 25%
 
         assertEq(vat.gem(ilk, ali), 0);
@@ -355,7 +355,6 @@ contract ClipperTest is DSTest {
 
         dai.mint(1000 ether);
         dai.transfer(address(exchange), 1000 ether);
-        dai.setOwner(address(daiJoin));
         gold.mint(1000 ether);
         gold.transfer(address(goldJoin), 1000 ether);
 
@@ -460,7 +459,7 @@ contract ClipperTest is DSTest {
         assertEq(tab, rad(110 ether));
         assertEq(lot, 40 ether);
         assertEq(usr, me);
-        assertEq(uint256(tic), now);
+        assertEq(uint256(tic), block.timestamp);
         assertEq(top, ray(4 ether));
         assertEq(vat.gem(ilk, me), 960 ether);
         assertEq(vat.dai(ali), rad(1100 ether)); // Paid "tip" amount of DAI for calling bark()
@@ -501,7 +500,7 @@ contract ClipperTest is DSTest {
         assertEq(tab, rad(110 ether));
         assertEq(lot, 40 ether);
         assertEq(usr, me);
-        assertEq(uint256(tic), now);
+        assertEq(uint256(tic), block.timestamp);
         assertEq(top, ray(5 ether));
         assertEq(vat.gem(ilk, me), 920 ether);
         (ink, art) = vat.urns(ilk, me);
@@ -587,7 +586,7 @@ contract ClipperTest is DSTest {
         assertEq(tab, rad(80 ether)); // No chop
         assertEq(lot, 32 ether);
         assertEq(usr, me);
-        assertEq(uint256(tic), now);
+        assertEq(uint256(tic), block.timestamp);
         assertEq(top, ray(4 ether));
         assertEq(vat.gem(ilk, me), 960 ether);
         (ink, art) = vat.urns(ilk, me);
@@ -629,7 +628,7 @@ contract ClipperTest is DSTest {
         assertEq(tab, rad(100 ether)); // No chop
         assertEq(lot, 40 ether);
         assertEq(usr, me);
-        assertEq(uint256(tic), now);
+        assertEq(uint256(tic), block.timestamp);
         assertEq(top, ray(4 ether));
         assertEq(vat.gem(ilk, me), 960 ether);
         (ink, art) = vat.urns(ilk, me);
@@ -679,7 +678,7 @@ contract ClipperTest is DSTest {
         assertEq(tab, mul(100 ether, rate));  // No chop
         assertEq(lot, 40 ether);
         assertEq(usr, me);
-        assertEq(uint256(tic), now);
+        assertEq(uint256(tic), block.timestamp);
         assertEq(top, ray(4 ether));
         assertEq(vat.gem(ilk, me), 960 ether);
         (ink, art) = vat.urns(ilk, me);
@@ -729,7 +728,7 @@ contract ClipperTest is DSTest {
         assertEq(tab, 816 * RAD / 10);  // Equal to ilk.hole
         assertEq(lot, 32 ether);
         assertEq(usr, me);
-        assertEq(uint256(tic), now);
+        assertEq(uint256(tic), block.timestamp);
         assertEq(top, ray(4 ether));
         assertEq(vat.gem(ilk, me), 960 ether);
         (ink, art) = vat.urns(ilk, me);
@@ -932,7 +931,7 @@ contract ClipperTest is DSTest {
         assertEq(tab, rad(55 ether));  // 110 - 5 * 11
         assertEq(lot, 29 ether);       // 40 - 11
         assertEq(usr, me);
-        assertEq(uint256(tic), now);
+        assertEq(uint256(tic), block.timestamp);
         assertEq(top, ray(5 ether));
 
         assertEq(dog.Dirt(), tab);
@@ -941,7 +940,7 @@ contract ClipperTest is DSTest {
     }
 
     function test_take_full_lot_partial_tab() public takeSetup {
-        hevm.warp(now + 69);  // approx 50% price decline
+        hevm.warp(block.timestamp + 69);  // approx 50% price decline
         // Bid to purchase entire lot less than tab (~2.5 * 40 ~= 100 < 110)
         Guy(ali).take({
             id:  1,
@@ -1007,7 +1006,7 @@ contract ClipperTest is DSTest {
     }
 
     function test_take_bid_avoids_recalculate_due_no_more_lot() public takeSetup {
-        hevm.warp(now + 60); // Reducing the price
+        hevm.warp(block.timestamp + 60); // Reducing the price
 
         (, uint256 tab, uint256 lot,,,) = clip.sales(1);
         assertEq(tab, rad(110 ether));
@@ -1095,10 +1094,10 @@ contract ClipperTest is DSTest {
         assertEq(tab, rad(60 ether));  // 110 - 5 * 10
         assertEq(lot, 30 ether);       // 40 - 10
         assertEq(usr, me);
-        assertEq(uint256(tic), now);
+        assertEq(uint256(tic), block.timestamp);
         assertEq(top, ray(5 ether));
 
-        hevm.warp(now + 30);
+        hevm.warp(block.timestamp + 30);
 
         (, uint256 _price, uint256 _lot,) = clip.getStatus(1);
         Guy(bob).take({
@@ -1368,17 +1367,17 @@ contract ClipperTest is DSTest {
         assertEq(tab, rad(110 ether));
         assertEq(lot, 40 ether);
 
-        hevm.warp(now + 300);
+        hevm.warp(block.timestamp + 300);
         clip.redo(1, address(123));
         assertEq(vat.dai(address(123)), clip.tip());
 
         clip.file("chip", 0.02 ether);     // Reward 2% of tab
-        hevm.warp(now + 300);
+        hevm.warp(block.timestamp + 300);
         clip.redo(1, address(234));
         assertEq(vat.dai(address(234)), clip.tip() + clip.chip() * tab / WAD);
 
         clip.file("tip", 0); // No more flat fee
-        hevm.warp(now + 300);
+        hevm.warp(block.timestamp + 300);
         clip.redo(1, address(345));
         assertEq(vat.dai(address(345)), clip.chip() * tab / WAD);
 
@@ -1386,7 +1385,7 @@ contract ClipperTest is DSTest {
         clip.upchost();
         assertEq(clip.chost(), 110 * RAD + 1);
 
-        hevm.warp(now + 300);
+        hevm.warp(block.timestamp + 300);
         clip.redo(1, address(456));
         assertEq(vat.dai(address(456)), 0);
 
@@ -1395,7 +1394,7 @@ contract ClipperTest is DSTest {
         clip.upchost();
         assertEq(clip.chost(), 22 * RAD);
 
-        hevm.warp(now + 100); // Reducing the price
+        hevm.warp(block.timestamp + 100); // Reducing the price
 
         (, uint256 price,,) = clip.getStatus(1);
         assertEq(price, 1830161706366147524653080130); // 1.83 RAY
@@ -1415,7 +1414,7 @@ contract ClipperTest is DSTest {
         // is calculated from oracle price ($4) to see if dusty
         assertEq(lot, 2 ether); // (2 * $4) < $20 quivalent (dusty collateral)
 
-        hevm.warp(now + 300);
+        hevm.warp(block.timestamp + 300);
         clip.redo(1, address(567));
         assertEq(vat.dai(address(567)), 0);
     }
@@ -1662,7 +1661,7 @@ contract ClipperTest is DSTest {
         uint256 preGas = gasleft();
         Guy(ali).bark(dog, ilk, me, address(ali));
         uint256 diffGas = preGas - gasleft();
-        log_named_uint("bark with kick gas", diffGas);
+        emit log_named_uint("bark with kick gas", diffGas);
     }
 
     function test_gas_partial_take() public takeSetup {
@@ -1676,7 +1675,7 @@ contract ClipperTest is DSTest {
             data: ""
         });
         uint256 diffGas = preGas - gasleft();
-        log_named_uint("partial take gas", diffGas);
+        emit log_named_uint("partial take gas", diffGas);
 
         assertEq(vat.gem(ilk, ali), 11 ether);  // Didn't take whole lot
         assertEq(vat.dai(ali), rad(945 ether)); // Paid half tab (55)
@@ -1688,7 +1687,7 @@ contract ClipperTest is DSTest {
         assertEq(tab, rad(55 ether));  // 110 - 5 * 11
         assertEq(lot, 29 ether);       // 40 - 11
         assertEq(usr, me);
-        assertEq(uint256(tic), now);
+        assertEq(uint256(tic), block.timestamp);
         assertEq(top, ray(5 ether));
     }
 
@@ -1704,7 +1703,7 @@ contract ClipperTest is DSTest {
             data: ""
         });
         uint256 diffGas = preGas - gasleft();
-        log_named_uint("full take gas", diffGas);
+        emit log_named_uint("full take gas", diffGas);
 
         assertEq(vat.gem(ilk, ali), 22 ether);  // Didn't take whole lot
         assertEq(vat.dai(ali), rad(890 ether)); // Didn't pay more than tab (110)

--- a/src/test/Dog.t.sol
+++ b/src/test/Dog.t.sol
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.13;
+
+import { DSTest } from "ds-test/test.sol";
+
+import { Vat } from "../Vat.sol";
+import { Dog } from "../Dog.sol";
+
+contract VowMock {
+    function fess (uint256 due) public {}
+}
+
+contract ClipperMock {
+    bytes32 public ilk;
+    function setIlk(bytes32 wat) external {
+        ilk = wat;
+    }
+    function kick(uint256, uint256, address, address)
+        external pure returns (uint256 id) {
+        id = 42;
+    }
+}
+
+contract DogTest is DSTest {
+
+    bytes32 constant ilk = "gold";
+    address constant usr = address(1337);
+    uint256 constant THOUSAND = 1E3;
+    uint256 constant WAD = 1E18;
+    uint256 constant RAY = 1E27;
+    uint256 constant RAD = 1E45;
+    Vat vat;
+    VowMock vow;
+    ClipperMock clip;
+    Dog dog;
+
+    function setUp() public {
+        vat = new Vat();
+        vat.init(ilk);
+        vat.file(ilk, "spot", THOUSAND * RAY);
+        vat.file(ilk, "dust", 100 * RAD);
+        vow = new VowMock();
+        clip = new ClipperMock();
+        clip.setIlk(ilk);
+        dog = new Dog(address(vat));
+        vat.rely(address(dog));
+        dog.file(ilk, "chop", 11 * WAD / 10);
+        dog.file("vow", address(vow));
+        dog.file(ilk, "clip", address(clip));
+        dog.file("Hole", 10 * THOUSAND * RAD);
+        dog.file(ilk, "hole", 10 * THOUSAND * RAD);
+    }
+
+    function test_file_chop() public {
+        dog.file(ilk, "chop", WAD);
+        dog.file(ilk, "chop", WAD * 113 / 100);
+    }
+
+    function testFail_file_chop_lt_WAD() public {
+        dog.file(ilk, "chop", WAD - 1);
+    }
+
+    function testFail_file_chop_eq_zero() public {
+        dog.file(ilk, "chop", 0);
+    }
+
+    function testFail_file_clip_wrong_ilk() public {
+        dog.file("mismatched_ilk", "clip", address(clip));
+    }
+
+    function setUrn(uint256 ink, uint256 art) internal {
+        vat.slip(ilk, usr, int256(ink));
+        (, uint256 rate,,,) = vat.ilks(ilk);
+        vat.suck(address(vow), address(vow), art * rate);
+        vat.grab(ilk, usr, usr, address(vow), int256(ink), int256(art));
+        (uint256 actualInk, uint256 actualArt) = vat.urns(ilk, usr);
+        assertEq(ink, actualInk);
+        assertEq(art, actualArt);
+    }
+
+    function isDusty() internal view returns (bool dusty) {
+        (, uint256 rate,,, uint256 dust) = vat.ilks(ilk);
+        (, uint256 art) = vat.urns(ilk, usr);
+        uint256 due = art * rate;
+        dusty = due > 0 && due < dust;
+    }
+
+    function test_bark_basic() public {
+        setUrn(WAD, 2 * THOUSAND * WAD);
+        dog.bark(ilk, usr, address(this));
+        (uint256 ink, uint256 art) = vat.urns(ilk, usr);
+        assertEq(ink, 0);
+        assertEq(art, 0);
+    }
+
+    function testFail_bark_not_unsafe() public {
+        setUrn(WAD, 500 * WAD);
+        dog.bark(ilk, usr, address(this));
+    }
+
+    // dog.bark will liquidate vaults even if they are dusty
+    function test_bark_dusty_vault() public {
+        uint256 dust = 200;
+        vat.file(ilk, "dust", dust * RAD);
+        setUrn(1, (dust / 2) * WAD);
+        assertTrue(isDusty());
+        dog.bark(ilk, usr, address(this));
+    }
+
+    function test_bark_partial_liquidation_dirt_exceeds_hole_to_avoid_dusty_remnant() public {
+        uint256 dust = 200;
+        vat.file(ilk, "dust", dust * RAD);
+        uint256 hole = 5 * THOUSAND;
+        dog.file(ilk, "hole", hole * RAD);
+        (, uint256 chop,,) = dog.ilks(ilk);
+        uint256 artStart = hole * WAD * WAD / chop + dust * WAD - 1;
+        setUrn(WAD, artStart);
+        dog.bark(ilk, usr, address(this));
+        assertTrue(!isDusty());
+        (, uint256 art) = vat.urns(ilk, usr);
+
+        // The full vault has been liquidated so as not to leave a dusty remnant,
+        // at the expense of slightly exceeding hole.
+        assertEq(art, 0);
+        (,,, uint256 dirt) = dog.ilks(ilk);
+        assertTrue(dirt > hole * RAD);
+        assertEq(dirt, artStart * RAY * chop / WAD);
+    }
+
+    function test_bark_partial_liquidation_dirt_does_not_exceed_hole_if_remnant_is_nondusty() public {
+        uint256 dust = 200;
+        vat.file(ilk, "dust", dust * RAD);
+        uint256 hole = 5 * THOUSAND;
+        dog.file(ilk, "hole", hole * RAD);
+        (, uint256 chop,,) = dog.ilks(ilk);
+        setUrn(WAD, hole * WAD * WAD / chop + dust * WAD);
+        dog.bark(ilk, usr, address(this));
+        assertTrue(!isDusty());
+        (, uint256 art) = vat.urns(ilk, usr);
+
+        // The vault remnant respects the dust limit, so we don't exceed hole to liquidate it.
+        assertEq(art, dust * WAD);
+        (,,, uint256 dirt) = dog.ilks(ilk);
+        assertTrue(dirt <= hole * RAD);
+        assertEq(dirt, hole * RAD * WAD / RAY / chop * RAY * chop / WAD);
+    }
+
+    function test_bark_partial_liquidation_Dirt_exceeds_Hole_to_avoid_dusty_remnant() public {
+        uint256 dust = 200;
+        vat.file(ilk, "dust", dust * RAD);
+        uint256 Hole = 5 * THOUSAND;
+        dog.file("Hole", Hole * RAD);
+        (, uint256 chop,,) = dog.ilks(ilk);
+        uint256 artStart = Hole * WAD * WAD / chop + dust * WAD - 1;
+        setUrn(WAD, artStart);
+        dog.bark(ilk, usr, address(this));
+        assertTrue(!isDusty());
+
+        // The full vault has been liquidated so as not to leave a dusty remnant,
+        // at the expense of slightly exceeding hole.
+        (, uint256 art) = vat.urns(ilk, usr);
+        assertEq(art, 0);
+        assertTrue(dog.Dirt() > Hole * RAD);
+        assertEq(dog.Dirt(), artStart * RAY * chop / WAD);
+    }
+
+    function test_bark_partial_liquidation_Dirt_does_not_exceed_Hole_if_remnant_is_nondusty() public {
+        uint256 dust = 200;
+        vat.file(ilk, "dust", dust * RAD);
+        uint256 Hole = 5 * THOUSAND;
+        dog.file("Hole", Hole * RAD);
+        (, uint256 chop,,) = dog.ilks(ilk);
+        setUrn(WAD, Hole * WAD * WAD / chop + dust * WAD);
+        dog.bark(ilk, usr, address(this));
+        assertTrue(!isDusty());
+
+        // The full vault has been liquidated so as not to leave a dusty remnant,
+        // at the expense of slightly exceeding hole.
+        (, uint256 art) = vat.urns(ilk, usr);
+        assertEq(art, dust * WAD);
+        assertTrue(dog.Dirt() <= Hole * RAD);
+        assertEq(dog.Dirt(), Hole * RAD * WAD / RAY / chop * RAY * chop / WAD);
+    }
+
+    // A previous version reverted if room was dusty, even if the Vault being liquidated
+    // was also dusty and would fit in the remaining hole/Hole room.
+    function test_bark_dusty_vault_dusty_room() public {
+        // Use a chop that will give nice round numbers
+        uint256 CHOP = 110 * WAD / 100;  // 10%
+        dog.file(ilk, "chop", CHOP);
+
+        // set both hole_i and Hole to the same value for this test
+        uint256 ROOM = 200;
+        uint256 HOLE = 33 * THOUSAND + ROOM;
+        dog.file(     "Hole", HOLE * RAD);
+        dog.file(ilk, "hole", HOLE * RAD);
+
+        // Test using a non-zero rate to ensure the code is handling stability fees correctly.
+        vat.fold(ilk, address(vow), (5 * int256(RAY)) / 10);
+        (, uint256 rate,,,) = vat.ilks(ilk);
+        assertEq(rate, (15 * RAY) / 10);
+
+        // First, make both holes nearly full.
+        setUrn(WAD, (HOLE - ROOM) * RAD / rate * WAD / CHOP);
+        dog.bark(ilk, usr, address(this));
+        assertEq(HOLE * RAD - dog.Dirt(), ROOM * RAD);
+        (,,, uint256 dirt) = dog.ilks(ilk);
+        assertEq(HOLE * RAD - dirt, ROOM * RAD);
+
+        // Create a small vault
+        uint256 DUST_1 = 30;
+        vat.file(ilk, "dust", DUST_1 * RAD);
+        setUrn(WAD / 10**4, DUST_1 * RAD / rate);
+
+        // Dust limit goes up!
+        uint256 DUST_2 = 1500;
+        vat.file(ilk, "dust", DUST_2 * RAD);
+
+        // The testing vault is now dusty
+        assertTrue(isDusty());
+
+        // In fact, there is only room to create dusty auctions at this point.
+        assertTrue(dog.Hole() - dog.Dirt() < DUST_2 * RAD * CHOP / WAD);
+        uint256 hole;
+        (,, hole, dirt) = dog.ilks(ilk);
+        assertTrue(hole - dirt < DUST_2 * RAD * CHOP / WAD);
+
+        // But...our Vault is small enough to fit in ROOM
+        assertTrue(DUST_1 * RAD * CHOP / WAD < ROOM * RAD);
+
+        // bark should still succeed
+        dog.bark(ilk, usr, address(this));
+    }
+
+    function try_bark(bytes32 ilk_, address usr_, address kpr_) internal returns (bool ok) {
+        string memory sig = "bark(bytes32,address,address)";
+        (ok,) = address(dog).call(abi.encodeWithSignature(sig, ilk_, usr_, kpr_));
+    }
+
+    function test_bark_do_not_create_dusty_auction_hole() public {
+        uint256 dust = 300;
+        vat.file(ilk, "dust", dust * RAD);
+        uint256 hole = 3 * THOUSAND;
+        dog.file(ilk, "hole", hole * RAD);
+
+        // Test using a non-zero rate to ensure the code is handling stability fees correctly.
+        vat.fold(ilk, address(vow), (5 * int256(RAY)) / 10);
+        (, uint256 rate,,,) = vat.ilks(ilk);
+        assertEq(rate, (15 * RAY) / 10);
+
+        (, uint256 chop,,) = dog.ilks(ilk);
+        setUrn(WAD, (hole - dust / 2) * RAD / rate * WAD / chop);
+        dog.bark(ilk, usr, address(this));
+
+        // Make sure any partial liquidation would be dusty (assuming non-dusty remnant)
+        (,,, uint256 dirt) = dog.ilks(ilk);
+        uint256 room = hole * RAD - dirt;
+        uint256 dart = room * WAD / rate / chop;
+        assertTrue(dart * rate < dust * RAD);
+
+        // This will need to be partially liquidated
+        setUrn(WAD, hole * WAD * WAD / chop);
+        assertTrue(!try_bark(ilk, usr, address(this)));  // should revert, as the auction would be dusty
+    }
+
+    function test_bark_do_not_create_dusty_auction_Hole() public {
+        uint256 dust = 300;
+        vat.file(ilk, "dust", dust * RAD);
+        uint256 Hole = 3 * THOUSAND;
+        dog.file("Hole", Hole * RAD);
+
+        // Test using a non-zero rate to ensure the code is handling stability fees correctly.
+        vat.fold(ilk, address(vow), (5 * int256(RAY)) / 10);
+        (, uint256 rate,,,) = vat.ilks(ilk);
+        assertEq(rate, (15 * RAY) / 10);
+
+        (, uint256 chop,,) = dog.ilks(ilk);
+        setUrn(WAD, (Hole - dust / 2) * RAD / rate * WAD / chop);
+        dog.bark(ilk, usr, address(this));
+
+        // Make sure any partial liquidation would be dusty (assuming non-dusty remnant)
+        uint256 room = Hole * RAD - dog.Dirt();
+        uint256 dart = room * WAD / rate / chop;
+        assertTrue(dart * rate < dust * RAD);
+
+        // This will need to be partially liquidated
+        setUrn(WAD, Hole * WAD * WAD / chop);
+        assertTrue(!try_bark(ilk, usr, address(this)));  // should revert, as the auction would be dusty
+    }
+}


### PR DESCRIPTION
NOTE: Core Vaults and Auctions are no longer part of the Maker Core roadmap.

`vow.fess()` is replaced in https://github.com/makerdao/xdomain-dss/pull/9 . Need to decide to merge that or re-add bad debt queueing in the `vow` again (I'm against this).