### PR TITLE
Handle bad debt inside dog/clipper instead of pushing to vow

### DIFF
--- a/src/Clipper.sol
+++ b/src/Clipper.sol
@@ -522,6 +522,7 @@ contract Clipper {
         require(sales[id].usr != address(0), "Clipper/not-running-auction");
         require(uint256(sales[id].tic) + wait <= block.timestamp, "Clipper/wait-not-elapsed");
         uint256 sin = sales[id].sin;
+        require(sin > 0, "Clipper/zero-sin");
         dog.flog(sin);
         vat.heal(sin);
         sales[id].sin = 0;

--- a/src/Clipper.sol
+++ b/src/Clipper.sol
@@ -25,6 +25,7 @@ interface VatLike {
     function ilks(bytes32) external returns (uint256, uint256, uint256, uint256, uint256);
     function suck(address,address,uint256) external;
     function dust(bytes32) external view returns (uint256);
+    function heal(uint256) external;
 }
 
 interface PipLike {
@@ -39,6 +40,7 @@ interface SpotterLike {
 interface DogLike {
     function chop(bytes32) external returns (uint256);
     function digs(bytes32, uint256) external;
+    function flog(uint256) external;
 }
 
 interface ClipperCallee {
@@ -67,12 +69,14 @@ contract Clipper {
     uint64  public chip;   // Percentage of tab to suck from vow to incentivize keepers         [wad]
     uint192 public tip;    // Flat fee to suck from vow to incentivize keepers                  [rad]
     uint256 public chost;  // Cache the ilk dust times the ilk chop to prevent excessive SLOADs [rad]
+    uint256 public wait;   // Delay before auction bad debt can be sent to vow                  [seconds]
 
     uint256   public kicks;   // Total auctions
     uint256[] public active;  // Array of active auction ids
 
     struct Sale {
         uint256 pos;  // Index in active array
+        uint256 sin;  // Bad Debt           [rad]
         uint256 tab;  // Dai to raise       [rad]
         uint256 lot;  // collateral to sell [wad]
         address usr;  // Liquidated CDP
@@ -100,6 +104,7 @@ contract Clipper {
     event Kick(
         uint256 indexed id,
         uint256 top,
+        uint256 sin,
         uint256 tab,
         uint256 lot,
         address indexed usr,
@@ -111,6 +116,7 @@ contract Clipper {
         uint256 max,
         uint256 price,
         uint256 owe,
+        uint256 sin,
         uint256 tab,
         uint256 lot,
         address indexed usr
@@ -126,6 +132,7 @@ contract Clipper {
     );
 
     event Yank(uint256 id);
+    event Flog(uint256 id, uint256 sin);
 
     modifier auth {
         require(wards[msg.sender] == 1, "Clipper/not-authorized");
@@ -173,6 +180,7 @@ contract Clipper {
         else if (what == "chip")       chip = uint64(data);   // Percentage of tab to incentivize (max: 2^64 - 1 => 18.xxx WAD = 18xx%)
         else if (what == "tip")         tip = uint192(data);  // Flat fee to incentivize keepers (max: 2^192 - 1 => 6.277T RAD)
         else if (what == "stopped") stopped = data;           // Set breaker (0, 1, 2, or 3)
+        else if (what == "wait")       wait = data;           // Set bad debt timeout
         else revert("Clipper/file-unrecognized-param");
         emit File(what, data);
     }
@@ -227,6 +235,7 @@ contract Clipper {
     // multiplicative factor to increase the starting price, and `par` is a
     // reference per DAI.
     function kick(
+        uint256 sin,  // Bad Debt               [rad]
         uint256 tab,  // Debt                   [rad]
         uint256 lot,  // Collateral             [wad]
         address usr,  // Address that will receive any leftover collateral
@@ -247,6 +256,7 @@ contract Clipper {
             sales[id].pos = active.length - 1;
         }
 
+        sales[id].sin = sin;
         sales[id].tab = tab;
         sales[id].lot = lot;
         sales[id].usr = usr;
@@ -266,7 +276,7 @@ contract Clipper {
             vat.suck(vow, kpr, coin);
         }
 
-        emit Kick(id, top, tab, lot, usr, kpr, coin);
+        emit Kick(id, top, sin, tab, lot, usr, kpr, coin);
     }
 
     // Reset an auction
@@ -355,6 +365,7 @@ contract Clipper {
 
         uint256 lot = sales[id].lot;
         uint256 tab = sales[id].tab;
+        uint256 sin = sales[id].sin;
         uint256 owe;
 
         {
@@ -403,8 +414,16 @@ contract Clipper {
                 ClipperCallee(who).clipperCall(msg.sender, owe, slice, data);
             }
 
-            // Get DAI from caller
-            vat.move(msg.sender, vow, owe);
+            // Get DAI from caller, heal the bad debt and send the rest to the vow
+            vat.move(msg.sender, address(this), owe);
+            uint256 heal = min(sin, owe);
+            if (sin > 0) {
+                vat.heal(heal);
+                unchecked {
+                    sin = sin - heal;
+                }
+            }
+            vat.move(address(this), vow, owe - heal);
 
             // Removes Dai out for liquidation from accumulator
             unchecked {
@@ -418,14 +437,22 @@ contract Clipper {
             vat.flux(ilk, address(this), usr, lot);
             _remove(id);
         } else {
+            sales[id].sin = sin;
             sales[id].tab = tab;
             sales[id].lot = lot;
         }
 
-        emit Take(id, max, price, owe, tab, lot, usr);
+        emit Take(id, max, price, owe, sin, tab, lot, usr);
     }
 
     function _remove(uint256 id) internal {
+        // Push any remaining sin to the vow
+        uint256 sin = sales[id].sin;
+        if (sin > 0) {
+            dog.flog(sin);
+            vat.heal(sin);
+        }
+
         uint256 _move;
         unchecked {
             _move = active[active.length - 1];
@@ -481,5 +508,16 @@ contract Clipper {
         vat.flux(ilk, address(this), msg.sender, sales[id].lot);
         _remove(id);
         emit Yank(id);
+    }
+
+    // Send auction bad debt to vow after wait period
+    function flog(uint256 id) external lock {
+        require(sales[id].usr != address(0), "Clipper/not-running-auction");
+        require(uint256(sales[id].tic) + wait <= block.timestamp, "Clipper/wait-not-elapsed");
+        uint256 sin = sales[id].sin;
+        dog.flog(sin);
+        vat.heal(sin);
+        sales[id].sin = 0;
+        emit Flog(id, sin);
     }
 }

--- a/src/Clipper.sol
+++ b/src/Clipper.sol
@@ -434,8 +434,10 @@ contract Clipper {
         }
 
         if (lot == 0) {
+            sales[id].sin = 0;
             _remove(id);
         } else if (tab == 0) {
+            sales[id].sin = 0;
             vat.flux(ilk, address(this), usr, lot);
             _remove(id);
         } else {

--- a/src/Dog.sol
+++ b/src/Dog.sol
@@ -224,24 +224,26 @@ contract Dog {
             ilk, urn, milk.clip, milk.clip, -int256(dink), -int256(dart)
         );
 
-        uint256 due = dart * rate;
-
         {   // Avoid stack too deep
             // This calcuation will overflow if dart*rate exceeds ~10^14
-            uint256 tab = due * milk.chop / WAD;
+            uint256 tab = (dart * rate) * milk.chop / WAD;
             Dirt = Dirt + tab;
             ilks[ilk].dirt = milk.dirt + tab;
 
-            id = ClipperLike(milk.clip).kick({
-                sin: due,
-                tab: tab,
-                lot: dink,
-                usr: urn,
-                kpr: kpr
-            });
+            unchecked {
+                id = ClipperLike(milk.clip).kick({
+                    sin: dart * rate,
+                    tab: tab,
+                    lot: dink,
+                    usr: urn,
+                    kpr: kpr
+                });
+            }
         }
 
-        emit Bark(ilk, urn, dink, dart, due, milk.clip, id);
+        unchecked {
+            emit Bark(ilk, urn, dink, dart, dart * rate, milk.clip, id);
+        }
     }
 
     function digs(bytes32 ilk, uint256 rad) external auth {

--- a/src/Dog.sol
+++ b/src/Dog.sol
@@ -22,6 +22,7 @@ pragma solidity ^0.8.13;
 interface ClipperLike {
     function ilk() external view returns (bytes32);
     function kick(
+        uint256 sin,
         uint256 tab,
         uint256 lot,
         address usr,
@@ -44,10 +45,7 @@ interface VatLike {
     function grab(bytes32,address,address,address,int256,int256) external;
     function hope(address) external;
     function nope(address) external;
-}
-
-interface VowLike {
-    function fess(uint256) external;
+    function suck(address,address,uint256) external;
 }
 
 contract Dog {
@@ -65,7 +63,7 @@ contract Dog {
 
     mapping (bytes32 => Ilk) public ilks;
 
-    VowLike public vow;   // Debt Engine
+    address public vow;   // Debt Engine
     uint256 public live;  // Active Flag
     uint256 public Hole;  // Max DAI needed to cover debt+fees of active auctions [rad]
     uint256 public Dirt;  // Amt DAI needed to cover debt+fees of active auctions [rad]
@@ -89,6 +87,7 @@ contract Dog {
       uint256 indexed id
     );
     event Digs(bytes32 indexed ilk, uint256 rad);
+    event Flog(address indexed clip, uint256 rad);
     event Cage();
 
     modifier auth {
@@ -123,7 +122,7 @@ contract Dog {
     }
 
     function file(bytes32 what, address data) external auth {
-        if (what == "vow") vow = VowLike(data);
+        if (what == "vow") vow = data;
         else revert("Dog/file-unrecognized-param");
         emit File(what, data);
     }
@@ -222,11 +221,10 @@ contract Dog {
         require(dart <= 2**255 && dink <= 2**255, "Dog/overflow");
 
         vat.grab(
-            ilk, urn, milk.clip, address(vow), -int256(dink), -int256(dart)
+            ilk, urn, milk.clip, milk.clip, -int256(dink), -int256(dart)
         );
 
         uint256 due = dart * rate;
-        vow.fess(due);
 
         {   // Avoid stack too deep
             // This calcuation will overflow if dart*rate exceeds ~10^14
@@ -235,6 +233,7 @@ contract Dog {
             ilks[ilk].dirt = milk.dirt + tab;
 
             id = ClipperLike(milk.clip).kick({
+                sin: due,
                 tab: tab,
                 lot: dink,
                 usr: urn,
@@ -249,6 +248,11 @@ contract Dog {
         Dirt = Dirt - rad;
         ilks[ilk].dirt = ilks[ilk].dirt - rad;
         emit Digs(ilk, rad);
+    }
+
+    function flog(uint256 rad) external auth {
+        vat.suck(address(vow), msg.sender, rad);
+        emit Flog(msg.sender, rad);
     }
 
     function cage() external auth {

--- a/src/test/Clipper.t.sol
+++ b/src/test/Clipper.t.sol
@@ -437,6 +437,7 @@ contract ClipperTest is DSTest {
         assertEq(clip.kicks(), 0);
         (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
+        assertEq(sin, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
         assertEq(usr, address(0));
@@ -453,12 +454,14 @@ contract ClipperTest is DSTest {
         assertEq(clip.kicks(), 1);
         (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
+        assertEq(sin, rad(100 ether));
         assertEq(tab, rad(110 ether));
         assertEq(lot, 40 ether);
         assertEq(usr, me);
         assertEq(uint256(tic), block.timestamp);
         assertEq(top, ray(4 ether));
         assertEq(vat.gem(ilk, me), 960 ether);
+        assertEq(vat.sin(address(clip)), rad(100 ether));
         assertEq(vat.dai(ali), rad(1100 ether)); // Paid "tip" amount of DAI for calling bark()
         (ink, art) = vat.urns(ilk, me);
         assertEq(ink, 0 ether);
@@ -475,12 +478,14 @@ contract ClipperTest is DSTest {
 
         (pos, sin, tab, lot, usr, tic, top) = clip.sales(2);
         assertEq(pos, 0);
+        assertEq(sin, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
         assertEq(usr, address(0));
         assertEq(uint256(tic), 0);
         assertEq(top, 0);
         assertEq(vat.gem(ilk, me), 920 ether);
+        assertEq(vat.sin(address(clip)), rad(100 ether));
 
         clip.file(bytes32("buf"),  ray(1.25 ether)); // 25% Initial price buffer
 
@@ -494,12 +499,14 @@ contract ClipperTest is DSTest {
         assertEq(clip.kicks(), 2);
         (pos, sin, tab, lot, usr, tic, top) = clip.sales(2);
         assertEq(pos, 1);
+        assertEq(sin, rad(100 ether));
         assertEq(tab, rad(110 ether));
         assertEq(lot, 40 ether);
         assertEq(usr, me);
         assertEq(uint256(tic), block.timestamp);
         assertEq(top, ray(5 ether));
         assertEq(vat.gem(ilk, me), 920 ether);
+        assertEq(vat.sin(address(clip)), rad(200 ether));
         (ink, art) = vat.urns(ilk, me);
         assertEq(ink, 0 ether);
         assertEq(art, 0 ether);
@@ -566,6 +573,7 @@ contract ClipperTest is DSTest {
         assertEq(clip.kicks(), 0);
         (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
+        assertEq(sin, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
         assertEq(usr, address(0));
@@ -581,6 +589,7 @@ contract ClipperTest is DSTest {
         assertEq(clip.kicks(), 1);
         (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
+        assertEq(sin, rad(80 ether));
         assertEq(tab, rad(80 ether)); // No chop
         assertEq(lot, 32 ether);
         assertEq(usr, me);
@@ -609,6 +618,7 @@ contract ClipperTest is DSTest {
         assertEq(clip.kicks(), 0);
         (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
+        assertEq(sin, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
         assertEq(usr, address(0));
@@ -624,6 +634,7 @@ contract ClipperTest is DSTest {
         assertEq(clip.kicks(), 1);
         (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
+        assertEq(sin, rad(100 ether));
         assertEq(tab, rad(100 ether)); // No chop
         assertEq(lot, 40 ether);
         assertEq(usr, me);
@@ -854,6 +865,8 @@ contract ClipperTest is DSTest {
     }
 
     function test_take_over_tab() public takeSetup {
+        assertEq(vat.sin(address(clip)), rad(100 ether));
+
         // Bid so owe (= 25 * 5 = 125 RAD) > tab (= 110 RAD)
         // Readjusts slice to be tab/top = 25
         Guy(ali).take({
@@ -867,10 +880,13 @@ contract ClipperTest is DSTest {
         assertEq(vat.gem(ilk, ali), 22 ether);  // Didn't take whole lot
         assertEq(vat.dai(ali), rad(890 ether)); // Didn't pay more than tab (110)
         assertEq(vat.gem(ilk, me),  978 ether); // 960 + (40 - 22) returned to usr
+        assertEq(vat.sin(address(clip)), 0);
 
         // Assert auction ends
         (uint256 pos, uint256 sin, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
         assertEq(pos, 0);
+        assertEq(sin, 0);
+        assertEq(vat.sin(address(clip)), 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
         assertEq(usr, address(0));
@@ -899,6 +915,7 @@ contract ClipperTest is DSTest {
         // Assert auction ends
         (uint256 pos, uint256 sin, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
         assertEq(pos, 0);
+        assertEq(sin, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
         assertEq(usr, address(0));
@@ -927,6 +944,8 @@ contract ClipperTest is DSTest {
         // Assert auction DOES NOT end
         (uint256 pos, uint256 sin, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
         assertEq(pos, 0);
+        assertEq(sin, rad(45 ether));  // 100 - 5 * 11
+        assertEq(vat.sin(address(clip)), rad(45 ether));
         assertEq(tab, rad(55 ether));  // 110 - 5 * 11
         assertEq(lot, 29 ether);       // 40 - 11
         assertEq(usr, me);
@@ -956,6 +975,7 @@ contract ClipperTest is DSTest {
         // Assert auction ends
         (uint256 pos, uint256 sin, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
         assertEq(pos, 0);
+        assertEq(sin, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
         assertEq(usr, address(0));
@@ -1091,6 +1111,8 @@ contract ClipperTest is DSTest {
         // Assert auction DOES NOT end
         (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
+        assertEq(sin, rad(50 ether));  // 100 - 5 * 10
+        assertEq(vat.sin(address(clip)), rad(50 ether));
         assertEq(tab, rad(60 ether));  // 110 - 5 * 10
         assertEq(lot, 30 ether);       // 40 - 10
         assertEq(usr, me);
@@ -1111,6 +1133,8 @@ contract ClipperTest is DSTest {
         // Assert auction is over
         (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
+        assertEq(sin, 0);
+        assertEq(vat.sin(address(clip)), 0);
         assertEq(tab, 0);
         assertEq(lot, 0 * WAD);
         assertEq(usr, address(0));
@@ -1240,6 +1264,7 @@ contract ClipperTest is DSTest {
         assertEq(clip.kicks(), 0);
         (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
+        assertEq(sin, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
         assertEq(usr, address(0));
@@ -1446,6 +1471,7 @@ contract ClipperTest is DSTest {
         // Assert that the auction was deleted.
         (uint256 pos, uint256 sin, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
         assertEq(pos, 0);
+        assertEq(sin, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
         assertEq(usr, address(0));

--- a/src/test/Clipper.t.sol
+++ b/src/test/Clipper.t.sol
@@ -16,10 +16,6 @@ import "../Dog.sol";
 
 import {MockToken} from "./mocks/Token.sol";
 
-contract VowMock {
-    function fess (uint256 due) public {}
-}
-
 interface Hevm {
     function warp(uint256) external;
     function store(address,bytes32,bytes32) external;
@@ -173,7 +169,7 @@ contract KickGuy is Guy {
         address sender, uint256 owe, uint256 slice, bytes calldata data
     ) external {
         sender; owe; slice; data;
-        clip.kick(1, 1, address(0), address(0));
+        clip.kick(1, 1, 1, address(0), address(0));
     }
 }
 
@@ -234,7 +230,7 @@ contract ClipperTest is DSTest {
     Vat     vat;
     Dog     dog;
     Spotter spot;
-    VowMock vow;
+    address vow;
     DSValue pip;
     MockToken gold;
     GemJoin goldJoin;
@@ -307,7 +303,7 @@ contract ClipperTest is DSTest {
         assertEq(ink, 0);
         assertEq(art, 0);
 
-        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        (pos,, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, rad(110 ether));
         assertEq(lot, 40 ether);
@@ -344,7 +340,7 @@ contract ClipperTest is DSTest {
         spot = new Spotter(address(vat));
         vat.rely(address(spot));
 
-        vow = new VowMock();
+        vow = address(123);
         gold = new MockToken("GLD");
         goldJoin = new GemJoin(address(vat), ilk, address(gold));
         vat.rely(address(goldJoin));
@@ -426,6 +422,7 @@ contract ClipperTest is DSTest {
 
     function test_kick() public {
         uint256 pos;
+        uint256 sin;
         uint256 tab;
         uint256 lot;
         address usr;
@@ -438,7 +435,7 @@ contract ClipperTest is DSTest {
         clip.file("chip", 0);              // No linear increase
 
         assertEq(clip.kicks(), 0);
-        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
@@ -454,7 +451,7 @@ contract ClipperTest is DSTest {
         Guy(ali).bark(dog, ilk, me, address(ali));
 
         assertEq(clip.kicks(), 1);
-        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, rad(110 ether));
         assertEq(lot, 40 ether);
@@ -476,7 +473,7 @@ contract ClipperTest is DSTest {
         pip.poke(bytes32(uint256(4 ether))); // Spot = $2
         spot.poke(ilk);          // Now unsafe
 
-        (pos, tab, lot, usr, tic, top) = clip.sales(2);
+        (pos, sin, tab, lot, usr, tic, top) = clip.sales(2);
         assertEq(pos, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
@@ -495,7 +492,7 @@ contract ClipperTest is DSTest {
         Guy(bob).bark(dog, ilk, me, address(bob));
 
         assertEq(clip.kicks(), 2);
-        (pos, tab, lot, usr, tic, top) = clip.sales(2);
+        (pos, sin, tab, lot, usr, tic, top) = clip.sales(2);
         assertEq(pos, 1);
         assertEq(tab, rad(110 ether));
         assertEq(lot, 40 ether);
@@ -554,6 +551,7 @@ contract ClipperTest is DSTest {
 
     function test_bark_not_leaving_dust() public {
         uint256 pos;
+        uint256 sin;
         uint256 tab;
         uint256 lot;
         address usr;
@@ -566,7 +564,7 @@ contract ClipperTest is DSTest {
         dog.file(ilk, "chop", 1 ether); // 0% chop (for precise calculations)
 
         assertEq(clip.kicks(), 0);
-        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
@@ -581,7 +579,7 @@ contract ClipperTest is DSTest {
         assertTrue(try_bark(ilk, me)); // art - dart = 100 - 80 = dust (= 20)
 
         assertEq(clip.kicks(), 1);
-        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, rad(80 ether)); // No chop
         assertEq(lot, 32 ether);
@@ -596,6 +594,7 @@ contract ClipperTest is DSTest {
 
     function test_bark_not_leaving_dust_over_hole() public {
         uint256 pos;
+        uint256 sin;
         uint256 tab;
         uint256 lot;
         address usr;
@@ -608,7 +607,7 @@ contract ClipperTest is DSTest {
         dog.file(ilk, "chop", 1 ether); // 0% chop (for precise calculations)
 
         assertEq(clip.kicks(), 0);
-        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
@@ -623,7 +622,7 @@ contract ClipperTest is DSTest {
         assertTrue(try_bark(ilk, me)); // art - dart = 100 - (80 + 1 wei) < dust (= 20) then the whole debt is taken
 
         assertEq(clip.kicks(), 1);
-        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, rad(100 ether)); // No chop
         assertEq(lot, 40 ether);
@@ -656,7 +655,7 @@ contract ClipperTest is DSTest {
         clip.upchost();
 
         assertEq(clip.kicks(), 0);
-        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        (pos,, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
@@ -673,7 +672,7 @@ contract ClipperTest is DSTest {
         assertTrue(try_bark(ilk, me));
 
         assertEq(clip.kicks(), 1);
-        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        (pos,, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, mul(100 ether, rate));  // No chop
         assertEq(lot, 40 ether);
@@ -706,7 +705,7 @@ contract ClipperTest is DSTest {
         clip.upchost();
 
         assertEq(clip.kicks(), 0);
-        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        (pos,, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
@@ -723,7 +722,7 @@ contract ClipperTest is DSTest {
         assertTrue(try_bark(ilk, me));
 
         assertEq(clip.kicks(), 1);
-        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        (pos,, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, 816 * RAD / 10);  // Equal to ilk.hole
         assertEq(lot, 32 ether);
@@ -745,7 +744,7 @@ contract ClipperTest is DSTest {
 
         dog.bark(ilk, me, address(this));
 
-        (, uint256 tab,,,,) = clip.sales(1);
+        (,, uint256 tab,,,,) = clip.sales(1);
 
         assertEq(dog.Dirt(), tab);
         (,,, dirt) = dog.ilks(ilk);
@@ -779,7 +778,7 @@ contract ClipperTest is DSTest {
 
         dog.bark(ilk2, me, address(this));
 
-        (, uint256 tab2,,,,) = clip2.sales(1);
+        (,, uint256 tab2,,,,) = clip2.sales(1);
 
         assertEq(dog.Dirt(), tab + tab2);
         (,,, dirt) = dog.ilks(ilk);
@@ -800,7 +799,7 @@ contract ClipperTest is DSTest {
 
         dog.bark(ilk, me, address(this));
 
-        (, uint256 tab, uint256 lot,,,) = clip.sales(1);
+        (,, uint256 tab, uint256 lot,,,) = clip.sales(1);
 
         (, uint256 rate,,,) = vat.ilks(ilk);
 
@@ -827,7 +826,7 @@ contract ClipperTest is DSTest {
 
         dog.bark(ilk, me, address(this));
 
-        (, uint256 tab, uint256 lot,,,) = clip.sales(1);
+        (,, uint256 tab, uint256 lot,,,) = clip.sales(1);
 
         (, uint256 rate,,,) = vat.ilks(ilk);
 
@@ -849,7 +848,7 @@ contract ClipperTest is DSTest {
 
     function test_take_zero_usr() public takeSetup {
         // Auction id 2 is unpopulated.
-        (,,, address usr,,) = clip.sales(2);
+        (,,,, address usr,,) = clip.sales(2);
         assertEq(usr, address(0));
         assertTrue(!try_take(2, 25 ether, ray(5 ether), address(ali), ""));
     }
@@ -870,7 +869,7 @@ contract ClipperTest is DSTest {
         assertEq(vat.gem(ilk, me),  978 ether); // 960 + (40 - 22) returned to usr
 
         // Assert auction ends
-        (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
+        (uint256 pos, uint256 sin, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
@@ -898,7 +897,7 @@ contract ClipperTest is DSTest {
         assertEq(vat.gem(ilk, me), 978 ether);  // 960 + (40 - 22) returned to usr
 
         // Assert auction ends
-        (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
+        (uint256 pos, uint256 sin, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
@@ -926,7 +925,7 @@ contract ClipperTest is DSTest {
         assertEq(vat.gem(ilk, me), 960 ether);  // Collateral not returned (yet)
 
         // Assert auction DOES NOT end
-        (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
+        (uint256 pos, uint256 sin, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, rad(55 ether));  // 110 - 5 * 11
         assertEq(lot, 29 ether);       // 40 - 11
@@ -955,7 +954,7 @@ contract ClipperTest is DSTest {
         assertEq(vat.gem(ilk, me), 960 ether);  // Collateral not returned
 
         // Assert auction ends
-        (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
+        (uint256 pos, uint256 sin, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
@@ -981,7 +980,7 @@ contract ClipperTest is DSTest {
     }
 
     function test_take_bid_recalculates_due_to_chost_check() public takeSetup {
-        (, uint256 tab, uint256 lot,,,) = clip.sales(1);
+        (,, uint256 tab, uint256 lot,,,) = clip.sales(1);
         assertEq(tab, rad(110 ether));
         assertEq(lot, 40 ether);
 
@@ -1000,7 +999,7 @@ contract ClipperTest is DSTest {
             data: ""
         });
 
-        (, tab, lot,,,) = clip.sales(1);
+        (,, tab, lot,,,) = clip.sales(1);
         assertEq(tab, clip.chost());
         assertEq(lot, 40 ether - (110 * RAD - clip.chost()) / price);
     }
@@ -1008,7 +1007,7 @@ contract ClipperTest is DSTest {
     function test_take_bid_avoids_recalculate_due_no_more_lot() public takeSetup {
         hevm.warp(block.timestamp + 60); // Reducing the price
 
-        (, uint256 tab, uint256 lot,,,) = clip.sales(1);
+        (,, uint256 tab, uint256 lot,,,) = clip.sales(1);
         assertEq(tab, rad(110 ether));
         assertEq(lot, 40 ether);
 
@@ -1028,7 +1027,7 @@ contract ClipperTest is DSTest {
         // 40 * 2.73 = 109.42...
         // It means a very low amount of tab (< dust) would remain but doesn't matter
         // as the auction is finished because there isn't more lot
-        (, tab, lot,,,) = clip.sales(1);
+        (,, tab, lot,,,) = clip.sales(1);
         assertEq(tab, 0);
         assertEq(lot, 0);
     }
@@ -1045,7 +1044,7 @@ contract ClipperTest is DSTest {
             data: ""
         });
 
-        (, uint256 tab, uint256 lot,,,) = clip.sales(1);
+        (,, uint256 tab, uint256 lot,,,) = clip.sales(1);
         assertEq(tab, rad(22 ether));
         assertEq(lot, 22.4 ether);
         assertTrue(!(tab > clip.chost()));
@@ -1069,6 +1068,7 @@ contract ClipperTest is DSTest {
 
     function test_take_multiple_bids_different_prices() public takeSetup {
         uint256 pos;
+        uint256 sin;
         uint256 tab;
         uint256 lot;
         address usr;
@@ -1089,7 +1089,7 @@ contract ClipperTest is DSTest {
         assertEq(vat.gem(ilk, me), 960 ether);  // Collateral not returned (yet)
 
         // Assert auction DOES NOT end
-        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, rad(60 ether));  // 110 - 5 * 10
         assertEq(lot, 30 ether);       // 40 - 10
@@ -1109,7 +1109,7 @@ contract ClipperTest is DSTest {
         });
 
         // Assert auction is over
-        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, 0);
         assertEq(lot, 0 * WAD);
@@ -1151,7 +1151,7 @@ contract ClipperTest is DSTest {
 
         pip.poke(bytes32(uint256(3 ether))); // Spot = $1.50 (update price before reset is called)
 
-        (,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
+        (,,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
         assertEq(uint256(ticBefore), startTime);
         assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
 
@@ -1164,7 +1164,7 @@ contract ClipperTest is DSTest {
         assertTrue(needsRedo);
         assertTrue(try_redo(1, address(this)));
 
-        (,,,, uint96 ticAfter, uint256 topAfter) = clip.sales(1);
+        (,,,,, uint96 ticAfter, uint256 topAfter) = clip.sales(1);
         assertEq(uint256(ticAfter), startTime + 3601 seconds);     // (now)
         assertEq(topAfter, ray(3.75 ether)); // $3 spot + 25% buffer = $5 (used most recent OSM price)
     }
@@ -1174,7 +1174,7 @@ contract ClipperTest is DSTest {
 
         pip.poke(bytes32(uint256(3 ether))); // Spot = $1.50 (update price before reset is called)
 
-        (,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
+        (,,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
         assertEq(uint256(ticBefore), startTime);
         assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
 
@@ -1187,7 +1187,7 @@ contract ClipperTest is DSTest {
         assertTrue(needsRedo);
         assertTrue(try_redo(1, address(this)));
 
-        (,,,, uint96 ticAfter, uint256 topAfter) = clip.sales(1);
+        (,,,,, uint96 ticAfter, uint256 topAfter) = clip.sales(1);
         assertEq(uint256(ticAfter), startTime + 1801 seconds);     // (now)
         assertEq(topAfter, ray(3.75 ether)); // $3 spot + 25% buffer = $3.75 (used most recent OSM price)
     }
@@ -1228,6 +1228,7 @@ contract ClipperTest is DSTest {
 
     function test_stopped_kick() public {
         uint256 pos;
+        uint256 sin;
         uint256 tab;
         uint256 lot;
         address usr;
@@ -1237,7 +1238,7 @@ contract ClipperTest is DSTest {
         uint256 art;
 
         assertEq(clip.kicks(), 0);
-        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        (pos, sin, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
@@ -1310,7 +1311,7 @@ contract ClipperTest is DSTest {
 
         pip.poke(bytes32(uint256(3 ether))); // Spot = $1.50 (update price before reset is called)
 
-        (,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
+        (,,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
         assertEq(uint256(ticBefore), startTime);
         assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
 
@@ -1319,7 +1320,7 @@ contract ClipperTest is DSTest {
         hevm.warp(startTime + 3601 seconds);
         assertTrue(try_redo(1, address(this)));
 
-        (,,,, uint96 ticAfter, uint256 topAfter) = clip.sales(1);
+        (,,,,, uint96 ticAfter, uint256 topAfter) = clip.sales(1);
         assertEq(uint256(ticAfter), startTime + 3601 seconds);     // (now)
         assertEq(topAfter, ray(3.75 ether)); // $3 spot + 25% buffer = $5 (used most recent OSM price)
     }
@@ -1331,7 +1332,7 @@ contract ClipperTest is DSTest {
 
         pip.poke(bytes32(uint256(3 ether))); // Spot = $1.50 (update price before reset is called)
 
-        (,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
+        (,,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
         assertEq(uint256(ticBefore), startTime);
         assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
 
@@ -1348,7 +1349,7 @@ contract ClipperTest is DSTest {
 
         pip.poke(bytes32(uint256(3 ether))); // Spot = $1.50 (update price before reset is called)
 
-        (,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
+        (,,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
         assertEq(uint256(ticBefore), startTime);
         assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
 
@@ -1362,7 +1363,7 @@ contract ClipperTest is DSTest {
         clip.file("tip",  rad(100 ether)); // Flat fee of 100 DAI
         clip.file("chip", 0);              // No linear increase
 
-        (, uint256 tab, uint256 lot,,,) = clip.sales(1);
+        (,, uint256 tab, uint256 lot,,,) = clip.sales(1);
 
         assertEq(tab, rad(110 ether));
         assertEq(lot, 40 ether);
@@ -1407,7 +1408,7 @@ contract ClipperTest is DSTest {
             data: ""
         });
 
-        (, tab, lot,,,) = clip.sales(1);
+        (,, tab, lot,,,) = clip.sales(1);
 
         assertEq(tab, rad(110 ether) - 38 ether * price); // > 22 DAI chost
         // When auction is reset the current price of lot
@@ -1435,7 +1436,7 @@ contract ClipperTest is DSTest {
 
     function test_Clipper_yank() public takeSetup {
         uint256 preGemBalance = vat.gem(ilk, address(this));
-        (,, uint256 origLot,,,) = clip.sales(1);
+        (,,, uint256 origLot,,,) = clip.sales(1);
 
         uint startGas = gasleft();
         clip.yank(1);
@@ -1443,7 +1444,7 @@ contract ClipperTest is DSTest {
         emit log_named_uint("yank gas", startGas - endGas);
 
         // Assert that the auction was deleted.
-        (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
+        (uint256 pos, uint256 sin, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
@@ -1485,7 +1486,7 @@ contract ClipperTest is DSTest {
         assertEq(pclip.active(0), 1);
         assertEq(pclip.active(1), 2);
         assertEq(pclip.active(2), 5);  // Swapped last for middle
-        (pos,,,,,) = pclip.sales(5);
+        (pos,,,,,,) = pclip.sales(5);
         assertEq(pos, 2);
         assertEq(pclip.active(3), 4);
 
@@ -1494,19 +1495,19 @@ contract ClipperTest is DSTest {
         // [1,2,5]
         assertEq(pclip.count(), 3);
 
-        (pos,,,,,) = pclip.sales(1);
+        (pos,,,,,,) = pclip.sales(1);
         assertEq(pos, 0); // Sale 1 in slot 0
         assertEq(pclip.active(0), 1);
 
-        (pos,,,,,) = pclip.sales(2);
+        (pos,,,,,,) = pclip.sales(2);
         assertEq(pos, 1); // Sale 2 in slot 1
         assertEq(pclip.active(1), 2);
 
-        (pos,,,,,) = pclip.sales(5);
+        (pos,,,,,,) = pclip.sales(5);
         assertEq(pos, 2); // Sale 5 in slot 2
         assertEq(pclip.active(2), 5); // Final element removed
 
-        (pos,,,,,) = pclip.sales(4);
+        (pos,,,,,,) = pclip.sales(4);
         assertEq(pos, 0); // Sale 4 was deleted. Returns 0
     }
 
@@ -1645,7 +1646,7 @@ contract ClipperTest is DSTest {
     function test_gas_bark_kick() public {
         // Assertions to make sure setup is as expected.
         assertEq(clip.kicks(), 0);
-        (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
+        (uint256 pos, uint256 sin, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);
@@ -1682,7 +1683,7 @@ contract ClipperTest is DSTest {
         assertEq(vat.gem(ilk, me), 960 ether);  // Collateral not returned (yet)
 
         // Assert auction DOES NOT end
-        (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
+        (uint256 pos, uint256 sin, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, rad(55 ether));  // 110 - 5 * 11
         assertEq(lot, 29 ether);       // 40 - 11
@@ -1710,7 +1711,7 @@ contract ClipperTest is DSTest {
         assertEq(vat.gem(ilk, me),  978 ether); // 960 + (40 - 22) returned to usr
 
         // Assert auction ends
-        (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
+        (uint256 pos, uint256 sin, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
         assertEq(pos, 0);
         assertEq(tab, 0);
         assertEq(lot, 0);

--- a/src/test/Clipper.t.sol
+++ b/src/test/Clipper.t.sol
@@ -523,25 +523,25 @@ contract ClipperTest is DSTest {
         clip.redo(1, address(this));
     }
 
-    function try_kick(uint256 tab, uint256 lot, address usr, address kpr) internal returns (bool ok) {
-        string memory sig = "kick(uint256,uint256,address,address)";
-        (ok,) = address(clip).call(abi.encodeWithSignature(sig, tab, lot, usr, kpr));
+    function try_kick(uint256 sin, uint256 tab, uint256 lot, address usr, address kpr) internal returns (bool ok) {
+        string memory sig = "kick(uint256,uint256,uint256,address,address)";
+        (ok,) = address(clip).call(abi.encodeWithSignature(sig, sin, tab, lot, usr, kpr));
     }
 
     function test_kick_basic() public {
-        assertTrue(try_kick(1 ether, 2 ether, address(1), address(this)));
+        assertTrue(try_kick(1 ether, 1 ether, 2 ether, address(1), address(this)));
     }
 
     function test_kick_zero_tab() public {
-        assertTrue(!try_kick(0, 2 ether, address(1), address(this)));
+        assertTrue(!try_kick(1 ether, 0, 2 ether, address(1), address(this)));
     }
 
     function test_kick_zero_lot() public {
-        assertTrue(!try_kick(1 ether, 0, address(1), address(this)));
+        assertTrue(!try_kick(1 ether, 1 ether, 0, address(1), address(this)));
     }
 
     function test_kick_zero_usr() public {
-        assertTrue(!try_kick(1 ether, 2 ether, address(0), address(this)));
+        assertTrue(!try_kick(1 ether, 1 ether, 2 ether, address(0), address(this)));
     }
 
     function try_bark(bytes32 ilk_, address urn_) internal returns (bool ok) {

--- a/src/test/Dog.t.sol
+++ b/src/test/Dog.t.sol
@@ -12,7 +12,7 @@ contract ClipperMock {
     function setIlk(bytes32 wat) external {
         ilk = wat;
     }
-    function kick(uint256, uint256, address, address)
+    function kick(uint256, uint256, uint256, address, address)
         external pure returns (uint256 id) {
         id = 42;
     }

--- a/src/test/Dog.t.sol
+++ b/src/test/Dog.t.sol
@@ -284,4 +284,14 @@ contract DogTest is DSTest {
         setUrn(WAD, Hole * WAD * WAD / chop);
         assertTrue(!try_bark(ilk, usr, address(this)));  // should revert, as the auction would be dusty
     }
+
+    function test_flog() public {
+        assertEq(vat.dai(address(this)), 0);
+        assertEq(vat.sin(address(vow)), 0);
+
+        dog.flog(100 * RAD);
+
+        assertEq(vat.dai(address(this)), 100 * RAD);
+        assertEq(vat.sin(address(vow)), 100 * RAD);
+    }
 }

--- a/src/test/Dog.t.sol
+++ b/src/test/Dog.t.sol
@@ -7,10 +7,6 @@ import { DSTest } from "ds-test/test.sol";
 import { Vat } from "../Vat.sol";
 import { Dog } from "../Dog.sol";
 
-contract VowMock {
-    function fess (uint256 due) public {}
-}
-
 contract ClipperMock {
     bytes32 public ilk;
     function setIlk(bytes32 wat) external {
@@ -31,7 +27,7 @@ contract DogTest is DSTest {
     uint256 constant RAY = 1E27;
     uint256 constant RAD = 1E45;
     Vat vat;
-    VowMock vow;
+    address vow;
     ClipperMock clip;
     Dog dog;
 
@@ -40,7 +36,7 @@ contract DogTest is DSTest {
         vat.init(ilk);
         vat.file(ilk, "spot", THOUSAND * RAY);
         vat.file(ilk, "dust", 100 * RAD);
-        vow = new VowMock();
+        vow = address(123);
         clip = new ClipperMock();
         clip.setIlk(ilk);
         dog = new Dog(address(vat));


### PR DESCRIPTION
NOTE: Core Vaults and Auctions are no longer part of the Maker Core roadmap.

This is change to remove `vow.fess()` and all the complexity of debt queueing in the vow. Bad debt is instead initially moved to the clipper and is only pushed to the vow when the auction finishes or if a timeout occurs.

This has the added benefit of allowing collateral set their own duration. For on-chain collateral like ETH a few days is fine, but for RWAs or heavily illiquid assets the duration will be longer. It doesn't make sense to define this in the `vow`.

Some considerations:

 * Is it an issue to move bad debt to the vow with `yank()` during global settlement?